### PR TITLE
add: requestAndConfirmAirdrop()

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,23 +17,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      # Install Solana
+
       # From https://docs.solana.com/cli/install-solana-cli-tools
-      - run: sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+      - name: Install Solana
+        run: sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
 
       - name: Add to PATH
-        shell: bash
-        run: |
-          echo "~/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+        run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
-      # Run Solana validator (and background it)
-      - run: solana-test-validator &
+      - name: Run Solana validator (and background it)
+        run: solana-test-validator &
 
-      # Install everything
-      - run: npm ci
+      - name: Install everything
+        run: npm ci
 
       - name: Check Solana keygen is installed
-        run: which solana-keygen
+        run: echo $PATH; which solana-keygen
 
-      # Run tests
-      - run: npm test
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           echo "~/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
-      # Run Solana validator
-      - run: solana-test-validator
+      # Run Solana validator (and background it)
+      - run: solana-test-validator &
 
       # Install everything
       - run: npm ci

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,10 @@ jobs:
       - name: Add to PATH
         shell: bash
         run: |
-          echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+          echo "~/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      # Run Solana validator
+      - run: solana-test-validator
 
       # Install everything
       - run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src/temp
 dist
 node_modules
+test-ledger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3
+
+- Now just `helpers`
+- Added `requestAndConfirmAirdrop`
+- Added `getCustomErrorMessage`
+
 ## 1.2
 
 - Added `addKeypairToEnvFile()`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ And `errorMessage` will now be:
 "This token mint cannot freeze accounts";
 ```
 
+## requestAndConfirmAirdrop()
+
+Request and confirm an airdrop in one step. This is built the next future version of web3.js, but we've added it here now for your convenience.
+
+```typescript
+const balance = await requestAndConfirmAirdrop(
+  connection,
+  keypair.publicKey,
+  lamportsToAirdrop,
+);
+```
+
+As soon as the `await` returns, the airdropped tokens will be ready in the address, and the new balance of tokens is returned by requestAndConfirmAirdrop(). This makes `requestAndConfirmAirdrop()` very handy in testing scripts.
+
 # node.js specific helpers
 
 ## getKeypairFromFile()
@@ -117,6 +131,20 @@ await addKeypairToEnvFile(testKeypair, "SECRET_KEY", ".env.local");
 ```
 
 This will also reload the env file
+
+## requestAndConfirmAirdrop()
+
+Request and confirm an airdrop in one step. This is built into the next version of web3.js, but we've added it here now for your convenience.
+
+```typescript
+await requestAndConfirmAirdrop(
+  connection,
+  keypair.publicKey,
+  lamportsToAirdrop,
+);
+```
+
+As soon as the `await` returns, the airdropped tokens will be ready in the address. This makes `requestAndConfirmAirdrop()` very handy in testing scripts. Note you may want to check the balance (`const balance = await connection.getBalance(keypair.publicKey);`) to ensure you only use your airdrops when you need them.
 
 ### Secret key format
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,76 @@
-# Solana node helpers
+# Solana helpers
 
-The `node-helpers` package package contains node.js specific Solana helper functions.
+The `helpers` package contains Solana helper functions, for use in the browser and/or node.js
 
-See `@solana/web3.js` for functions that work in both the browser and node.js.
+Eventually most of these will end up in `@solana/web3.js`.
 
 ## Installation
 
 ```bash
 npm i @solana-developers/node-helpers
 ```
+
+# helpers for the browser and node.js
+
+## getCustomErrorMessage()
+
+Sometimes Solana libaries return an error like:
+
+> failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x10
+
+`getCustomErrorMessage()` allows you to turn this message into the more readable message that matches the number message from the custom program:
+
+> This token mint cannot freeze accounts"
+
+Just:
+
+- Get the errors from your programs `error.rs` file - for example, there are [the errors for the Token Program](https://github.com/solana-labs/solana-program-library/blob/master/token/program/src/error.rs)
+
+- Save the errors into an array
+
+```
+// Token program errors
+// https://github.com/solana-labs/solana-program-library/blob/master/token/program/src/error.rs
+const programErrors = [
+  "Lamport balance below rent-exempt threshold",
+  "Insufficient funds",
+  "Invalid Mint",
+  "Account not associated with this Mint",
+  "Owner does not match",
+  "Fixed supply",
+  "Already in use",
+  "Invalid number of provided signers",
+  "Invalid number of required signers",
+  "State is unititialized",
+  "Instruction does not support native tokens",
+  "Non-native account can only be closed if its balance is zero",
+  "Invalid instruction",
+  "State is invalid for requested operation",
+  "Operation overflowed",
+  "Account does not support specified authority type",
+  "This token mint cannot freeze accounts",
+  "Account is frozen",
+  "The provided decimals value different from the Mint decimals",
+  "Instruction does not support non-native tokens",
+];
+```
+
+Then run:
+
+```
+const errorMessage = getCustomErrorMessage(
+  programErrors,
+  "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x10",
+);
+```
+
+And `errorMessage` will now be:
+
+```
+"This token mint cannot freeze accounts";
+```
+
+# node.js specific helpers
 
 ## getKeypairFromFile()
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@solana-developers/node-helpers",
-  "version": "1.2.2",
-  "description": "Solana helper functions for node.js",
+  "name": "@solana-developers/helpers",
+  "version": "1.3.0",
+  "description": "Solana helper functions",
   "main": "dist/index.js",
   "private": false,
   "scripts": {
@@ -19,14 +19,14 @@
   "author": "Mike MacCana <mike.maccana@solana.org>",
   "license": "MIT",
   "dependencies": {
-    "@digitak/esrun": "^3.2.24",
+    "@solana/web3.js": "^1.78.4",
     "bs58": "^5.0.0",
     "dotenv": "^16.3.1",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@solana/web3.js": "^1.78.4",
+    "@digitak/esrun": "^3.2.24",
     "@types/node": "^20.5.7",
     "tsup": "^7.2.0"
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import {
   getKeypairFromEnvironment,
   getKeypairFromFile,
   addKeypairToEnvFile,
+  getCustomErrorMessage,
 } from "./index";
 import { Keypair } from "@solana/web3.js";
 import assert from "node:assert/strict";
@@ -18,6 +19,40 @@ const exec = promisify(execNoPromises);
 const log = console.log;
 
 const TEMP_DIR = "src/temp";
+
+describe(`getCustomErrorMessage`, () => {
+  test(`we turn error messages with hex codes into error messages for the program`, () => {
+    // This example set of error is from the token program
+    // https://github.com/solana-labs/solana-program-library/blob/master/token/program/src/error.rs
+    const programErrors = [
+      "Lamport balance below rent-exempt threshold",
+      "Insufficient funds",
+      "Invalid Mint",
+      "Account not associated with this Mint",
+      "Owner does not match",
+      "Fixed supply",
+      "Already in use",
+      "Invalid number of provided signers",
+      "Invalid number of required signers",
+      "State is unititialized",
+      "Instruction does not support native tokens",
+      "Non-native account can only be closed if its balance is zero",
+      "Invalid instruction",
+      "State is invalid for requested operation",
+      "Operation overflowed",
+      "Account does not support specified authority type",
+      "This token mint cannot freeze accounts",
+      "Account is frozen",
+      "The provided decimals value different from the Mint decimals",
+      "Instruction does not support non-native tokens",
+    ];
+    const errorMessage = getCustomErrorMessage(
+      programErrors,
+      "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x10",
+    );
+    assert.equal(errorMessage, "This token mint cannot freeze accounts");
+  });
+});
 
 describe("getKeypairFromFile", () => {
   let TEST_FILE_NAME = `${TEMP_DIR}/test-keyfile-do-not-use.json`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,8 +4,9 @@ import {
   getKeypairFromFile,
   addKeypairToEnvFile,
   getCustomErrorMessage,
+  requestAndConfirmAirdrop,
 } from "./index";
-import { Keypair } from "@solana/web3.js";
+import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import assert from "node:assert/strict";
 import base58 from "bs58";
 // See https://m.media-amazon.com/images/I/51TJeGHxyTL._SY445_SX342_.jpg
@@ -166,5 +167,22 @@ describe("addKeypairToEnvFile", () => {
         message: `'TEST_ENV_VAR_ARRAY_OF_NUMBERS' already exists in env file.`,
       },
     );
+  });
+});
+
+describe("requestAndConfirmAirdrop", () => {
+  test("Checking the balance after requestAndConfirmAirdrop", async () => {
+    const keypair = Keypair.generate();
+    const connection = new Connection("http://127.0.0.1:8899");
+    const originalBalance = await connection.getBalance(keypair.publicKey);
+    const lamportsToAirdrop = 1 * LAMPORTS_PER_SOL;
+    assert.equal(originalBalance, 0);
+    const newBalance = await requestAndConfirmAirdrop(
+      connection,
+      keypair.publicKey,
+      lamportsToAirdrop,
+    );
+
+    assert.equal(newBalance, lamportsToAirdrop);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Keypair } from "@solana/web3.js";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import base58 from "bs58";
 import path from "path";
 import { readFile, appendFile } from "fs/promises";
@@ -108,4 +108,26 @@ export const addKeypairToEnvFile = async (
   }
   const secretKeyString = keypairToSecretKeyJSON(keypair);
   await appendFile(fileName, `\n${variableName}=${secretKeyString}`);
+};
+
+export const requestAndConfirmAirdrop = async (
+  connection: Connection,
+  publicKey: PublicKey,
+  amount: number,
+) => {
+  let airdropTransactionSignature = await connection.requestAirdrop(
+    publicKey,
+    amount,
+  );
+  // Wait for airdrop confirmation
+  const latestBlockHash = await connection.getLatestBlockhash();
+  await connection.confirmTransaction(
+    {
+      blockhash: latestBlockHash.blockhash,
+      lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
+      signature: airdropTransactionSignature,
+    },
+    "confirmed",
+  );
+  return connection.getBalance(publicKey, "confirmed");
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,23 @@ export const keypairToSecretKeyJSON = (keypair: Keypair): string => {
   return JSON.stringify(Array.from(keypair.secretKey));
 };
 
+export const getCustomErrorMessage = (
+  possibleProgramErrors: Array<string>,
+  errorMessage: string,
+): string | null => {
+  const customErrorExpression =
+    /.*custom program error: 0x(?<errorNumber>[0-9abcdef]+)/;
+
+  let match = customErrorExpression.exec(errorMessage);
+  const errorNumberFound = match?.groups?.errorNumber;
+  if (!errorNumberFound) {
+    return null;
+  }
+  // errorNumberFound is a base16 string
+  const errorNumber = parseInt(errorNumberFound, 16);
+  return possibleProgramErrors[errorNumber] || null;
+};
+
 export const getKeypairFromFile = async (filepath?: string) => {
   // Work out correct file name
   if (!filepath) {


### PR DESCRIPTION
So [the new web3.js has requestAndConfirmAirdrop()](https://github.com/solana-labs/solana-web3.js/blob/b31535247346c200cbc728cf4c108b2bbcfb1d00/packages/library/src/airdrop.ts#L30). Which is great, but the new web3.js is not out yet. 

We need a quick way to have airdrops 'just work' in the meantime. 

@nickfrosty this isn't technically node. Maybe we should make a `browser-helpers` and add it there instead?