### PR TITLE
add: requestAndConfirmAirdropIfRequired()

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ const balance = await requestAndConfirmAirdrop(
 
 As soon as the `await` returns, the airdropped tokens will be ready in the address, and the new balance of tokens is returned by requestAndConfirmAirdrop(). This makes `requestAndConfirmAirdrop()` very handy in testing scripts.
 
+## requestAndConfirmAirdropIfRequired()
+
+If you're running the same script repeatedly, you probably don't want to request airdrops on every single run. So to ask for 1 SOL, if the balance is below 0.5 SOL, you can use:
+
+```typescript
+const newBalance = await requestAndConfirmAirdropIfRequired(
+  connection,
+  keypair.publicKey,
+  1 * LAMPORTS_PER_SOL,
+  0.5 * LAMPORTS_PER_SOL,
+);
+```
+
 ## node.js specific helpers
 
 ### getKeypairFromFile()
@@ -166,7 +179,13 @@ We always save keys using the 'array of numbers' format, since most other Solana
 
 ## Development
 
-To run tests
+To run tests - open a terminal tab, and run:
+
+```
+solana-test-validator
+```
+
+Then in a different tab, run:
 
 ```
 npm run test

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,3 +131,16 @@ export const requestAndConfirmAirdrop = async (
   );
   return connection.getBalance(publicKey, "confirmed");
 };
+
+export const requestAndConfirmAirdropIfRequired = async (
+  connection: Connection,
+  publicKey: PublicKey,
+  airdropAmount: number,
+  minimumBalance: number,
+): Promise<number> => {
+  const balance = await connection.getBalance(publicKey, "confirmed");
+  if (balance < minimumBalance) {
+    return requestAndConfirmAirdrop(connection, publicKey, airdropAmount);
+  }
+  return balance;
+};


### PR DESCRIPTION
We have an requestAndConfirmAirdropIfRequired() in the course. It just airdrops if the balance is below some amount. Common use case is people want to run and re-run same scripts but not harass the poor devnet faucet.