### PR TITLE
refactor: replace both airdrop functions with one that always checks the existing balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0
 
 - **Breaking**: Replace both `requestAndConfirmAirdropIfRequired()` and `requestAndConfirmAirdrop()` with a single function, `airdropIfRequired()`. See [README.md]!
+- Fix error handling in `confirmTransaction()` to throw errors correctly.
 
 ## 1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0
+
+- **Breaking**: Replace both `requestAndConfirmAirdropIfRequired()` and `requestAndConfirmAirdrop()` with a single function, `airdropIfRequired()`. See [README.md]!
+
 ## 1.5
 
 - Added `getExplorerLink()`

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Eventually most of these will end up in `@solana/web3.js`.
 
 [Resolve a custom error message](#getcustomerrormessageprogramerrors-errormessage)
 
-[Get an airdrop, and wait until it's confirmed](#requestandconfirmairdropconnection-publickey-lamports)
-
-[Get an airdrop if your balance is below some amount](#requestandconfirmairdropifrequiredconnection-publickey-lamports-maximumbalance)
+[Get an airdrop if your balance is below some amount, and wait until it's confirmed](#airdropIfRequired-publickey-lamports-maximumbalance)
 
 [Get a Solana Explorer link for a transaction, address, or block](#getexplorerlinktype-identifier-clustername)
 
@@ -98,32 +96,18 @@ And `errorMessage` will now be:
 "This token mint cannot freeze accounts";
 ```
 
-### requestAndConfirmAirdrop(connection, publicKey, lamports)
+### airdropIfRequired(connection, publicKey, lamports, maximumBalance)
 
-Request and confirm an airdrop in one step. This is built into the next future version of web3.js, but we've added it here now for your convenience.
+Request and confirm an airdrop in one step. As soon as the `await` returns, the airdropped tokens will be ready in the address, and the new balance of tokens is returned. The `maximumBalance` is used to avoid errors caused by unneccessarily asking for SOL when there's already enough in the account, and makes `airdropIfRequired()` very handy in scripts that run repeatedly.
 
-```typescript
-const balance = await requestAndConfirmAirdrop(
-  connection,
-  keypair.publicKey,
-  lamportsToAirdrop,
-);
-```
-
-As soon as the `await` returns, the airdropped tokens will be ready in the address, and the new balance of tokens is returned by requestAndConfirmAirdrop(). This makes `requestAndConfirmAirdrop()` very handy in testing scripts.
-
-Note you may want to use `requestAndConfirmAirdropIfRequired()` (see below) to ensure you only use your airdrops when you need them.
-
-### requestAndConfirmAirdropIfRequired(connection, publicKey, lamports, maximumBalance)
-
-If you're running the same script repeatedly, you probably don't want to request airdrops on every single run. So to ask for 1 SOL, if the balance is below 0.5 SOL, you can use:
+To ask for 0.5 SOL, if the balance is below 1 SOL, use:
 
 ```typescript
-const newBalance = await requestAndConfirmAirdropIfRequired(
+const newBalance = await airdropIfRequired(
   connection,
   keypair.publicKey,
-  1 * LAMPORTS_PER_SOL,
   0.5 * LAMPORTS_PER_SOL,
+  1 * LAMPORTS_PER_SOL,
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Eventually most of these will end up in `@solana/web3.js`.
 
 [Resolve a custom error message](#getcustomerrormessageprogramerrors-errormessage)
 
-[Get an airdrop if your balance is below some amount, and wait until it's confirmed](#airdropIfRequired-publickey-lamports-maximumbalance)
+[Get an airdrop if your balance is below some amount, and wait until it's confirmed](#airdropifrequiredconnection-publickey-lamports-maximumbalance)
 
 [Get a Solana Explorer link for a transaction, address, or block](#getexplorerlinktype-identifier-clustername)
 
@@ -98,7 +98,7 @@ And `errorMessage` will now be:
 
 ### airdropIfRequired(connection, publicKey, lamports, maximumBalance)
 
-Request and confirm an airdrop in one step. As soon as the `await` returns, the airdropped tokens will be ready in the address, and the new balance of tokens is returned. The `maximumBalance` is used to avoid errors caused by unneccessarily asking for SOL when there's already enough in the account, and makes `airdropIfRequired()` very handy in scripts that run repeatedly.
+Request and confirm an airdrop in one step. As soon as the `await` returns, the airdropped tokens will be ready in the address, and the new balance of tokens is returned. The `maximumBalance` is used to avoid errors caused by unnecessarily asking for SOL when there's already enough in the account, and makes `airdropIfRequired()` very handy in scripts that run repeatedly.
 
 To ask for 0.5 SOL, if the balance is below 1 SOL, use:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "description": "Solana helper functions",
   "main": "dist/index.js",
   "private": false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -193,10 +193,24 @@ describe("airdropIfRequired", () => {
       connection,
       keypair.publicKey,
       lamportsToAirdrop,
-      500_000,
+      1 * LAMPORTS_PER_SOL,
     );
 
     assert.equal(newBalance, lamportsToAirdrop);
+
+    const recipient = Keypair.generate();
+
+    // Spend our SOL now to ensure we can use the airdrop immediately
+    await connection.sendTransaction(
+      new Transaction().add(
+        SystemProgram.transfer({
+          fromPubkey: keypair.publicKey,
+          toPubkey: recipient.publicKey,
+          lamports: 500_000_000,
+        }),
+      ),
+      [keypair],
+    );
   });
 
   test("doesn't request unnecessary airdrops", async () => {
@@ -300,10 +314,11 @@ describe.only("confirmTransaction", () => {
     const connection = new Connection(LOCALHOST);
     const [sender, recipient] = [Keypair.generate(), Keypair.generate()];
     const lamportsToAirdrop = 2 * LAMPORTS_PER_SOL;
-    await requestAndConfirmAirdrop(
+    await airdropIfRequired(
       connection,
       sender.publicKey,
       lamportsToAirdrop,
+      1 * LAMPORTS_PER_SOL,
     );
 
     const transaction = await connection.sendTransaction(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,8 +4,7 @@ import {
   getKeypairFromFile,
   addKeypairToEnvFile,
   getCustomErrorMessage,
-  requestAndConfirmAirdrop,
-  requestAndConfirmAirdropIfRequired,
+  airdropIfRequired,
   getExplorerLink,
   confirmTransaction,
   makeKeypairs,
@@ -182,38 +181,38 @@ describe("addKeypairToEnvFile", () => {
   });
 });
 
-describe("requestAndConfirmAirdrop", () => {
-  test("Checking the balance after requestAndConfirmAirdrop", async () => {
+describe("airdropIfRequired", () => {
+  test("Checking the balance after airdropIfRequired", async () => {
     const keypair = Keypair.generate();
     const connection = new Connection(LOCALHOST);
     const originalBalance = await connection.getBalance(keypair.publicKey);
     assert.equal(originalBalance, 0);
     const lamportsToAirdrop = 1 * LAMPORTS_PER_SOL;
 
-    const newBalance = await requestAndConfirmAirdrop(
+    const newBalance = await airdropIfRequired(
       connection,
       keypair.publicKey,
       lamportsToAirdrop,
+      500_000,
     );
 
     assert.equal(newBalance, lamportsToAirdrop);
   });
-});
 
-describe("requestAndConfirmAirdropIfRequired", () => {
-  test("requestAndConfirmAirdropIfRequired doesn't request unnecessary airdrops", async () => {
+  test("doesn't request unnecessary airdrops", async () => {
     const keypair = Keypair.generate();
     const connection = new Connection(LOCALHOST);
     const originalBalance = await connection.getBalance(keypair.publicKey);
     assert.equal(originalBalance, 0);
     const lamportsToAirdrop = 1 * LAMPORTS_PER_SOL;
 
-    await requestAndConfirmAirdrop(
+    await airdropIfRequired(
       connection,
       keypair.publicKey,
       lamportsToAirdrop,
+      500_000,
     );
-    const finalBalance = await requestAndConfirmAirdropIfRequired(
+    const finalBalance = await airdropIfRequired(
       connection,
       keypair.publicKey,
       lamportsToAirdrop,
@@ -223,20 +222,21 @@ describe("requestAndConfirmAirdropIfRequired", () => {
     assert.equal(finalBalance, 1 * lamportsToAirdrop);
   });
 
-  test("requestAndConfirmAirdropIfRequired does airdrop when necessary", async () => {
+  test("airdropIfRequired does airdrop when necessary", async () => {
     const keypair = Keypair.generate();
     const connection = new Connection(LOCALHOST);
     const originalBalance = await connection.getBalance(keypair.publicKey);
     assert.equal(originalBalance, 0);
-    // Ensure we are just below threshhold for second airdrop to happen
+    // Get 999_999_999 lamports if we have less than 500_000 lamports
     const lamportsToAirdrop = 1 * LAMPORTS_PER_SOL - 1;
-    await requestAndConfirmAirdrop(
+    await airdropIfRequired(
       connection,
       keypair.publicKey,
       lamportsToAirdrop,
+      500_000,
     );
     // We only have 999_999_999 lamports, so we should need another airdrop
-    const finalBalance = await requestAndConfirmAirdropIfRequired(
+    const finalBalance = await airdropIfRequired(
       connection,
       keypair.publicKey,
       1 * LAMPORTS_PER_SOL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,7 @@ const requestAndConfirmAirdrop = async (
       lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
       signature: airdropTransactionSignature,
     },
-    // "finalised" is slow but we must be absolutely sure
+    // "finalized" is slow but we must be absolutely sure
     // the airdrop has gone through
     "finalized",
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,10 @@ export const addKeypairToEnvFile = async (
   await appendFile(fileName, `\n${variableName}=${secretKeyString}`);
 };
 
-export const requestAndConfirmAirdrop = async (
+// Not exported as we don't want to encourage people to
+// request airdrops when they don't need them, ie - don't bother
+// the faucet unless you really need to!
+const requestAndConfirmAirdrop = async (
   connection: Connection,
   publicKey: PublicKey,
   amount: number,
@@ -170,7 +173,7 @@ export const requestAndConfirmAirdrop = async (
   return connection.getBalance(publicKey, "finalized");
 };
 
-export const requestAndConfirmAirdropIfRequired = async (
+export const airdropIfRequired = async (
   connection: Connection,
   publicKey: PublicKey,
   airdropAmount: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,8 @@ const requestAndConfirmAirdrop = async (
       lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
       signature: airdropTransactionSignature,
     },
+    // "finalised" is slow but we must be absolutely sure
+    // the airdrop has gone through
     "finalized",
   );
   return connection.getBalance(publicKey, "finalized");


### PR DESCRIPTION
Per #13 

Also we need to use 'finalized'. While the balance may show updated after using 'confirmed', actually sending the airdropped tokens won't work unless it's 'finalized'.