### PR TITLE
Add makeKeypairs(), tests and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ npm i @solana-developers/helpers
 
 ### getCustomErrorMessage(programErrors, errorMessage)
 
-Sometimes Solana libaries return an error like:
+Sometimes Solana transactions throw an error with a message like:
 
 > failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x10
 
-`getCustomErrorMessage()` allows you to turn this message into the more readable message that matches the number message from the custom program, like:
+`getCustomErrorMessage()` allows you to turn this message into a more readable message from the custom program, like:
 
 > This token mint cannot freeze accounts
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Eventually most of these will end up in `@solana/web3.js`.
 
 [Get a Solana Explorer link for a transaction, address, or block](#getexplorerlinktype-identifier-clustername)
 
+[Make a bunch of keypairs at once](#makekeypairs-amount)
+
 [Get a keypair from a keypair file (like id.json)](#getkeypairfromfilefilename)
 
 [Get a keypair from an environment variable](#getkeypairfromenvironmentenvironmentvariable)
@@ -144,6 +146,16 @@ getExplorerLink("block", "241889720", "mainnet-beta");
 ```
 
 Will return `"https://explorer.solana.com/block/241889720"`
+
+### makeKeypairs(amount)
+
+Particularly in tests, Solana developers often need to make multiple keypairs at once. So just:
+
+```
+const [alice, bob, tokenA, tokenB] = makeKeypairs(4);
+```
+
+And you'll now have `alice`, `bob`, `tokenA` and `tokenB` as distinct keypairs.
 
 ## node.js specific helpers
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -316,6 +316,7 @@ describe("makeKeypairs", () => {
     const keypairs = makeKeypairs(KEYPAIRS_TO_MAKE);
     assert.equal(keypairs.length, KEYPAIRS_TO_MAKE);
     assert.ok(keypairs[KEYPAIRS_TO_MAKE - 1].secretKey);
+  });
 });
 
 describe.only("confirmTransaction", () => {
@@ -349,5 +350,5 @@ describe("makeKeypairs", () => {
   test("makeKeypairs() creates the correct number of keypairs", () => {
     const keypairs = makeKeypairs(3);
     assert.equal(keypairs.length, 3);
-
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   requestAndConfirmAirdrop,
   requestAndConfirmAirdropIfRequired,
   getExplorerLink,
+  makeKeypairs,
 } from "./index";
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import assert from "node:assert/strict";
@@ -284,5 +285,15 @@ describe("getExplorerLink", () => {
   test("getExplorerLink works for a block on mainnet", () => {
     const link = getExplorerLink("block", "241889720", "mainnet-beta");
     assert.equal(link, "https://explorer.solana.com/block/241889720");
+  });
+});
+
+describe("makeKeypairs", () => {
+  test("makeKeypairs makes exactly the amount of keypairs requested", () => {
+    // We could test more, but keypair generation takes time and slows down tests
+    const KEYPAIRS_TO_MAKE = 3;
+    const keypairs = makeKeypairs(KEYPAIRS_TO_MAKE);
+    assert.equal(keypairs.length, KEYPAIRS_TO_MAKE);
+    assert.ok(keypairs[KEYPAIRS_TO_MAKE - 1].secretKey);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Cluster, Connection, Keypair, PublicKey } from "@solana/web3.js";
 import base58 from "bs58";
 import path from "path";
 import { readFile, appendFile } from "fs/promises";
+
 const log = console.log;
 
 // Default value from Solana CLI
@@ -181,4 +182,9 @@ export const requestAndConfirmAirdropIfRequired = async (
     return requestAndConfirmAirdrop(connection, publicKey, airdropAmount);
   }
   return balance;
+};
+
+// Shout out to Dean from WBA for this technique
+export const makeKeypairs = (amount: number): Array<Keypair> => {
+  return Array.from({ length: amount }, () => Keypair.generate());
 };


### PR DESCRIPTION
Got this idea from @deanmlittle, it's particularly useful for setup functions in tests:

```
const [alice, bob, tokenAmint, tokenBmint] = makeKeypairs(4);
```