### PR TITLE
refactor: make web3.js dependency less specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@solana/web3.js": "^1.78.4",
+    "@solana/web3.js": "^1",
     "bs58": "^5.0.0",
     "dotenv": "^16.3.1",
     "prettier": "^3.0.3",


### PR DESCRIPTION
See https://stackoverflow.com/a/25861938/123671. Saying 'any 1.x version' should be enough to make the version of web3.js installed by the parent project be considered sufficient, and deduplication will ensure only one copy is installed.

Fixes #19 