### PR TITLE
Add get logs, plus various minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Eventually most of these will end up in `@solana/web3.js`.
 
 [Get a Solana Explorer link for a transaction, address, or block](#getexplorerlinktype-identifier-clustername)
 
-[Confirm a transaction (includes getting a recent blockhash)](#confirmTransaction)
+[Confirm a transaction (includes getting a recent blockhash)](#confirmtransaction-connection-transaction)
 
-[Get a keypair from a keypair file (like id.json)](#getkeypairfromfilefilename)
+[Get a transaction's logs](#getlogs-connection-transaction)
+
+[Get a keypair from a keypair file (like id.json)](#getkeypairfromfilename)
 
 [Get a keypair from an environment variable](#getkeypairfromenvironmentenvironmentvariable)
 
@@ -148,6 +150,25 @@ Confirm a transaction, and also gets the recent blockhash required to confirm it
 ```typescript
 await confirmTransaction(connection, transaction);
 ```
+
+### getLogs(connection, transaction)
+
+Get the logs for a transaction signature:
+
+```typescript
+const logs = await getLogs(connection, transaction);
+```
+
+The `logs` will be an array of strings, eg:
+
+```
+[
+  "Program 11111111111111111111111111111111 invoke [1]",
+  "Program 11111111111111111111111111111111 success",
+];
+```
+
+This a good way to assert your onchain programs returned particular logs during unit tests.
 
 ## node.js specific helpers
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -310,7 +310,7 @@ describe("getExplorerLink", () => {
   });
 });
 
-describe.only("confirmTransaction", () => {
+describe("confirmTransaction", () => {
   test("confirmTransaction works for a successful transaction", async () => {
     const connection = new Connection(LOCALHOST);
     const [sender, recipient] = [Keypair.generate(), Keypair.generate()];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   getExplorerLink,
   confirmTransaction,
   makeKeypairs,
+  getLogs,
 } from "./index";
 import {
   Connection,
@@ -340,5 +341,36 @@ describe("makeKeypairs", () => {
   test("makeKeypairs() creates the correct number of keypairs", () => {
     const keypairs = makeKeypairs(3);
     assert.equal(keypairs.length, 3);
+  });
+});
+
+describe(`getLogs`, () => {
+  test(`getLogs works`, async () => {
+    const connection = new Connection(LOCALHOST);
+    const [sender, recipient] = [Keypair.generate(), Keypair.generate()];
+    const lamportsToAirdrop = 2 * LAMPORTS_PER_SOL;
+    await airdropIfRequired(
+      connection,
+      sender.publicKey,
+      lamportsToAirdrop,
+      1 * LAMPORTS_PER_SOL,
+    );
+
+    const transaction = await connection.sendTransaction(
+      new Transaction().add(
+        SystemProgram.transfer({
+          fromPubkey: sender.publicKey,
+          toPubkey: recipient.publicKey,
+          lamports: 1_000_000,
+        }),
+      ),
+      [sender],
+    );
+
+    const logs = await getLogs(connection, transaction);
+    assert.deepEqual(logs, [
+      "Program 11111111111111111111111111111111 invoke [1]",
+      "Program 11111111111111111111111111111111 success",
+    ]);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,13 +198,13 @@ export const confirmTransaction = async (
     ...block,
   });
 
-  /**
-   * note: `confirmTransaction` does not throw an error if the confirmation does not succeed,
-   * but rather a `TransactionError` object. so we handle that here
-   *
-   * https://solana-labs.github.io/solana-web3.js/classes/Connection.html#confirmTransaction.confirmTransaction-1
-   */
-  if (!!res.value.err) throw Error(res.value.err.toString());
+  // Note: `confirmTransaction` does not throw an error if the confirmation does not succeed,
+  // but rather a `TransactionError` object. so we handle that here
+  // See https://solana-labs.github.io/solana-web3.js/classes/Connection.html#confirmTransaction.confirmTransaction-1
+  const error = res.value.err;
+  if (error) {
+    throw Error(error.toString());
+  }
 
   return signature;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,15 +193,18 @@ export const confirmTransaction = async (
   signature: string,
 ): Promise<string> => {
   const block = await connection.getLatestBlockhash();
-  const res = await connection.confirmTransaction({
-    signature,
-    ...block,
-  });
+  const result = await connection.confirmTransaction(
+    {
+      signature,
+      ...block,
+    },
+    "confirmed",
+  );
 
   // Note: `confirmTransaction` does not throw an error if the confirmation does not succeed,
   // but rather a `TransactionError` object. so we handle that here
   // See https://solana-labs.github.io/solana-web3.js/classes/Connection.html#confirmTransaction.confirmTransaction-1
-  const error = res.value.err;
+  const error = result.value.err;
   if (error) {
     throw Error(error.toString());
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,3 +213,15 @@ export const confirmTransaction = async (
 export const makeKeypairs = (amount: number): Array<Keypair> => {
   return Array.from({ length: amount }, () => Keypair.generate());
 };
+
+export const getLogs = async (
+  connection: Connection,
+  tx: string,
+): Promise<Array<string>> => {
+  await confirmTransaction(connection, tx);
+  const txDetails = await connection.getTransaction(tx, {
+    maxSupportedTransactionVersion: 0,
+    commitment: "confirmed",
+  });
+  return txDetails?.meta?.logMessages || [];
+};


### PR DESCRIPTION
**Review and merge after https://github.com/solana-developers/helpers/pull/14** since this sits on top of that work. Once that's merged this will be much smaller.

 - Add getLogs() which gets logs from a transaction
 - Various minor fixes:
   - Need to set confirmation strategy explicitly
   - Remove an unused 'only' from tests
   - Remove not-not on null variable, since null is already falsy. 