### PR TITLE
Added one-line function initializeKeypair for quick startup for dev labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Eventually most of these will end up in `@solana/web3.js`.
 
 [Add a new keypair to an env file](#addkeypairtoenvfilekeypair-environmentvariable-file)
 
+[Load and airdrop to a keypair](#initializekeypairconnection-options)
+
 ## Installation
 
 ```bash
@@ -231,6 +233,56 @@ await addKeypairToEnvFile(testKeypair, "SECRET_KEY", ".env.local");
 ```
 
 This will also reload the env file
+
+### initializeKeypair(connection, options)
+
+Loads in a keypair from the filesystem, or environment and then airdrops to it if needed. 
+
+How the keypair is initialized is dependant on the `initializeKeypairOptions`:
+
+```typescript
+interface initializeKeypairOptions {
+  envFileName?: string;
+  envVariableName?: string;
+  airdropAmount?: number;
+  minimumBalance?: number;
+  keypairPath?: string;
+}
+```
+
+By default, the keypair will be retrieved from the `.env` file. If a `.env` file does not exist, this function will create one with a new keypair under the optional `envVariableName`.
+
+To load the keypair from the filesystem, pass in the `keypairPath`.
+
+After the keypair has been loaded, it will check the account's balance. If the balance is below the `minimumBalance`, it will airdrop the account `airdropAmount`.
+
+To initialize a keypair from the `.env` file, and airdrop it 1 sol if it's beneath 0.5 sol:
+```typescript
+const keypair = await initializeKeypair(connection);
+```
+
+To initialize a keypair from the `.env` file under a different variable name:
+```typescript
+const keypair = await initializeKeypair(connection, {
+  envVariableName: 'TEST_KEYPAIR'
+});
+```
+
+To initialize a keypair from the filesystem, and airdrop it 3 sol:
+```typescript
+const keypair = await initializeKeypair(connection, {
+  keypairPath: '~/.config/solana/id.json',
+  airdropAmount: LAMPORTS_PER_SOL * 3
+});
+```
+
+The default options are as follows:
+
+```typescript
+const DEFAULT_AIRDROP_AMOUNT = 1 * LAMPORTS_PER_SOL; 
+const DEFAULT_MINIMUM_BALANCE = 0.5 * LAMPORTS_PER_SOL;
+const DEFAULT_ENV_KEYPAIR_VARIABLE_NAME = "PRIVATE_KEY";
+```
 
 ## Secret key format
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "contributors": [
     "Nick Frostbutter",
     "John Liu",
-    "Steven Luscher"
+    "Steven Luscher",
+    "Christian Krueger"
   ],
   "license": "MIT",
   "dependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,9 +30,6 @@ import dotenv from "dotenv";
 const exec = promisify(execNoPromises);
 
 const LOCALHOST = "http://127.0.0.1:8899";
-
-const log = console.log;
-
 const TEMP_DIR = "src/temp";
 
 describe(`getCustomErrorMessage`, () => {
@@ -186,50 +183,7 @@ describe("addKeypairToEnvFile", () => {
 
 describe("initializeKeypair", () => {
   const connection = new Connection(LOCALHOST);
-  const keypairVariableName = "TEMP_KEYPAIR";
-
-  test("generates a new keypair and airdrops needed amount", async () => {
-    const options: initializeKeypairOptions = {
-      variableName: keypairVariableName,
-    };
-
-    const signerFirstLoad = await initializeKeypair(connection, options);
-
-    // Check balance
-    const firstBalanceLoad = await connection.getBalance(
-      signerFirstLoad.publicKey,
-    );
-    assert.ok(firstBalanceLoad > 0);
-
-    // Check that the environment variable was created
-    dotenv.config();
-    const secretKeyString = process.env[keypairVariableName];
-    if (!secretKeyString) {
-      throw new Error(`${secretKeyString} not found in environment`);
-    }
-
-    // Now reload the environment and check it matches our test keypair
-    const signerSecondLoad = await initializeKeypair(connection, options);
-
-    // Check the keypair is the same
-    assert.ok(signerFirstLoad.publicKey.equals(signerSecondLoad.publicKey));
-
-    // Check balance has not changed
-    const secondBalanceLoad = await connection.getBalance(
-      signerSecondLoad.publicKey,
-    );
-    assert.equal(firstBalanceLoad, secondBalanceLoad);
-
-    // Check there is a secret key
-    assert.ok(signerSecondLoad.secretKey);
-
-    await deleteFile(".env");
-  });
-});
-
-describe("initializeKeypair", () => {
-  const connection = new Connection(LOCALHOST);
-  const keypairVariableName = "TEMP_KEYPAIR";
+  const keypairVariableName = "INITIALIZE_KEYPAIR_TEST";
 
   test("generates a new keypair and airdrops needed amount", async () => {
     const options: initializeKeypairOptions = {
@@ -406,15 +360,10 @@ describe("makeKeypairs", () => {
     assert.equal(keypairs.length, KEYPAIRS_TO_MAKE);
     assert.ok(keypairs[KEYPAIRS_TO_MAKE - 1].secretKey);
   });
-});
 
-describe("makeKeypairs", () => {
-  test("makeKeypairs makes exactly the amount of keypairs requested", () => {
-    // We could test more, but keypair generation takes time and slows down tests
-    const KEYPAIRS_TO_MAKE = 3;
-    const keypairs = makeKeypairs(KEYPAIRS_TO_MAKE);
-    assert.equal(keypairs.length, KEYPAIRS_TO_MAKE);
-    assert.ok(keypairs[KEYPAIRS_TO_MAKE - 1].secretKey);
+  test("makeKeypairs() creates the correct number of keypairs", () => {
+    const keypairs = makeKeypairs(3);
+    assert.equal(keypairs.length, 3);
   });
 });
 
@@ -442,13 +391,6 @@ describe("confirmTransaction", () => {
     );
 
     await confirmTransaction(connection, transaction);
-  });
-});
-
-describe("makeKeypairs", () => {
-  test("makeKeypairs() creates the correct number of keypairs", () => {
-    const keypairs = makeKeypairs(3);
-    assert.equal(keypairs.length, 3);
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -170,7 +170,7 @@ describe("addKeypairToEnvFile", () => {
 
     assert.ok(envKeypair.secretKey);
 
-    deleteFile(".env");
+    await deleteFile(".env");
   });
 
   test("throws a nice error if the env var already exists", async () => {
@@ -223,7 +223,7 @@ describe("initializeKeypair", () => {
     // Check there is a secret key
     assert.ok(signerSecondLoad.secretKey);
 
-    deleteFile(".env");
+    await deleteFile(".env");
   });
 });
 
@@ -266,7 +266,7 @@ describe("initializeKeypair", () => {
     // Check there is a secret key
     assert.ok(signerSecondLoad.secretKey);
 
-    deleteFile(".env");
+    await deleteFile(".env");
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -187,7 +187,7 @@ describe("initializeKeypair", () => {
 
   test("generates a new keypair and airdrops needed amount", async () => {
     const options: initializeKeypairOptions = {
-      variableName: keypairVariableName,
+      envVariableName: keypairVariableName,
     };
 
     const signerFirstLoad = await initializeKeypair(connection, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,62 +200,7 @@ export const initializeKeypair = async (
     await addKeypairToEnvFile(signer, variableName, envFileName);
   }
 
-  await requestAndConfirmAirdropIfRequired(
-    connection,
-    signer.publicKey,
-    airdropAmount || LAMPORTS_PER_SOL,
-    minimumBalance || LAMPORTS_PER_SOL >> 1,
-  );
-
-  return signer;
-};
-
-export interface initializeKeypairOptions {
-  envFileName?: string; // .env file path
-  variableName?: string; // Variable name to call the secret key in the environment file
-  airdropAmount?: number; // Optional amount to airdrop in lamports
-  minimumBalance?: number; // Optional minimum balance to maintain in lamports
-  keypairPath?: string; // Optional path to a keypair file, if not provided, will look for the keypair in the environment
-}
-
-/**
- * Loads a keypair from the environment or generates a new one if not found and writes it to the environment,
- * then requests an airdrop if the balance is below the minimum balance
- *
- * @param connection Connection to the Solana cluster
- * @param options initializeKeypairOptions
- * - envFileName: .env file path
- * - variableName: Variable name to call the secret key in the environment file
- * - airdropAmount: Optional amount to airdrop in lamports
- * - minimumBalance: Optional minimum balance to maintain in lamports
- * - keypairPath: Optional path to a keypair file, if not provided, will look for the keypair in the environment
- * @returns A keypair with funds loaded
- */
-export const initializeKeypair = async (
-  connection: Connection,
-  options?: initializeKeypairOptions,
-): Promise<Keypair> => {
-  let {
-    envFileName,
-    variableName,
-    airdropAmount,
-    minimumBalance,
-    keypairPath,
-  } = options || {};
-
-  let signer: Keypair;
-  variableName = variableName || "PRIVATE_KEY";
-
-  if (keypairPath) {
-    signer = await getKeypairFromFile(keypairPath);
-  } else if (process.env[variableName]) {
-    signer = getKeypairFromEnvironment(variableName);
-  } else {
-    signer = Keypair.generate();
-    await addKeypairToEnvFile(signer, variableName, envFileName);
-  }
-
-  await requestAndConfirmAirdropIfRequired(
+  await airdropIfRequired(
     connection,
     signer.publicKey,
     airdropAmount || LAMPORTS_PER_SOL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Cluster, Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { Cluster, Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import base58 from "bs58";
 import path from "path";
 import { readFile, appendFile } from "fs/promises";
@@ -148,12 +148,59 @@ export const addKeypairToEnvFile = async (
   await appendFile(fileName, `\n${variableName}=${secretKeyString}`);
 };
 
+export interface initializeKeypairOptions {
+  envFileName?: string; // .env file path
+  variableName?: string; // Variable name to call the secret key in the environment file
+  airdropAmount?: number; // Optional amount to airdrop in lamports
+  minimumBalance?: number; // Optional minimum balance to maintain in lamports
+  keypairPath?: string; // Optional path to a keypair file, if not provided, will look for the keypair in the environment
+}
+
+/**
+ * Loads a keypair from the environment or generates a new one if not found and writes it to the environment,
+ * then requests an airdrop if the balance is below the minimum balance
+ * 
+ * @param connection Connection to the Solana cluster
+ * @param options initializeKeypairOptions
+ * - envFileName: .env file path
+ * - variableName: Variable name to call the secret key in the environment file
+ * - airdropAmount: Optional amount to airdrop in lamports
+ * - minimumBalance: Optional minimum balance to maintain in lamports
+ * - keypairPath: Optional path to a keypair file, if not provided, will look for the keypair in the environment
+ * @returns A keypair with funds loaded
+ */
+export const initializeKeypair = async (connection: Connection, options?: initializeKeypairOptions): Promise<Keypair> => {
+  let { envFileName, variableName, airdropAmount, minimumBalance, keypairPath } = options || {};
+
+  let signer: Keypair;
+  variableName = variableName || "PRIVATE_KEY";
+
+  if(keypairPath) {
+    signer = await getKeypairFromFile(keypairPath);
+  } else if (process.env[variableName]) {
+    signer = getKeypairFromEnvironment(variableName);
+  } else {
+    signer = Keypair.generate();
+    await addKeypairToEnvFile(signer, variableName, envFileName);
+  }
+
+  await requestAndConfirmAirdropIfRequired(
+    connection,
+    signer.publicKey, 
+    airdropAmount || LAMPORTS_PER_SOL,
+    minimumBalance || LAMPORTS_PER_SOL >> 1,
+  );
+
+  return signer;
+}
+
+
 export const requestAndConfirmAirdrop = async (
   connection: Connection,
   publicKey: PublicKey,
   amount: number,
 ) => {
-  let airdropTransactionSignature = await connection.requestAirdrop(
+  const airdropTransactionSignature = await connection.requestAirdrop(
     publicKey,
     amount,
   );


### PR DESCRIPTION
 Adding new function: initializeKeypair
 * Loads a keypair from the environment or generates a new one if not found and writes it to the environment,
 * then requests an airdrop if the balance is below the minimum balance