### PR TITLE
add getSimulationComputeUnits(), docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ const sendSol = SystemProgram.transfer({
 
 Then use `getSimulationComputeUnits` to get the number of compute units they will use:
 
-```
+```typescript
 const computeUnits = await getSimulationComputeUnits(
   connection,
   [sendSol],

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Eventually most of these will end up in `@solana/web3.js`.
 
 [Get the logs for a transaction](#get-the-logs-for-a-transaction)
 
+[Get simulated compute units (CUs) for transaction instructions](<#get-simulated-compute-units-(cus)-for-transaction-instructions>)
+
 [Get a keypair from a keypair file](#get-a-keypair-from-a-keypair-file)
 
 [Get a keypair from an environment variable](#get-a-keypair-from-an-environment-variable)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solana helpers
 
-The `helpers` package contains Solana helper functions, for use in the browser and/or node.js, [made by the Solana Foundation Developer Ecosystem team](https://youtu.be/zvQIa68ObK8?t=319) and our friends at [Anza](https://anza.xyz), [Turbin3](https://turbin3.com/) and [Unboxed Software](https://beunboxed.com/).
+The `helpers` package contains Solana helper functions, for use in the browser and/or node.js, [made by the Solana Foundation Developer Ecosystem team](https://youtu.be/zvQIa68ObK8?t=319) and our friends at [Anza](https://anza.xyz), [Turbin3](https://turbin3.com/), [Unboxed Software](https://beunboxed.com/) and [StarAtlas](https://staratlas.com/).
 
 Eventually most of these will end up in `@solana/web3.js`.
 
@@ -217,6 +217,30 @@ The `logs` will be an array of strings, eg:
 ```
 
 This a good way to assert your onchain programs return particular logs during unit tests.
+
+### Get simulated compute units (CUs) for transaction instructions
+
+Usage:
+
+```typescript
+getSimulationComputeUnits(connection, instructions, payer, lookupTables);
+```
+
+Get the compute units required for an array of instructions.
+
+```typescript
+const sendSol = SystemProgram.transfer({
+  fromPubkey: sender.publicKey,
+  toPubkey: recipient,
+  lamports: 1_000_000,
+});
+
+const computeUnits = await getSimulationComputeUnits(
+  connection,
+  [sendSol],
+  sender.publicKey,
+);
+```
 
 ## node.js specific helpers
 

--- a/README.md
+++ b/README.md
@@ -226,19 +226,23 @@ Usage:
 getSimulationComputeUnits(connection, instructions, payer, lookupTables);
 ```
 
-Get the compute units required for an array of instructions.
+Get the compute units required for an array of instructions. Create your instructions:
 
 ```typescript
 const sendSol = SystemProgram.transfer({
-  fromPubkey: sender.publicKey,
+  fromPubkey: payer.publicKey,
   toPubkey: recipient,
   lamports: 1_000_000,
 });
+```
 
+Then use `getSimulationComputeUnits` to get the number of compute units they will use:
+
+```
 const computeUnits = await getSimulationComputeUnits(
   connection,
   [sendSol],
-  sender.publicKey,
+  payer.publicKey,
 );
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,6 @@ const getErrorFromRPCResponse = (
   // but rather a `TransactionError` object. so we handle that here
   // See https://solana-labs.github.io/solana-web3.js/classes/Connection.html#confirmTransaction.confirmTransaction-1
 
-  // log(
-  //   `DEBUG rpcResponse`,
-  //   stringify(rpcResponse.value.err),
-  //   rpcResponse?.value?.err?.constructor.name,
-  // );
-
   const error = rpcResponse.value.err;
   if (error) {
     // Can be a string or an object (literally just {}, no further typing is provided by the library)

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,6 +347,7 @@ export const getSimulationComputeUnits = async (
     new TransactionMessage({
       instructions: testInstructions,
       payerKey: payer,
+      // It seems that recentBlockhash can by any public key duiring simulation
       recentBlockhash: PublicKey.default.toString(),
     }).compileToV0Message(lookupTables),
   );


### PR DESCRIPTION
- add getSimulationComputeUnits() based on @stegaBOB's original code (thanks @stegabob!), with some minor changes to fit in with the rest of the code.
- add tests - just a sol transfer, and then a sol transfer and memo checking the CUs calculated in each against a pre-confirmed value. 
- add docs

@jacobcreech I marked you as reviewer for this one as you seem to know the most about CU usage. There's some TODOs, specifically I think it would be good to know exactly why these instructions use the amounts of CU they are. The Memo program seems really high! 

@nickfrosty you're obviously welcome to check this out yourself as usual.

@stegabob I know you're on holiday so feel free to ignore but would love to get any feedback.