### PR TITLE
feat: skipping airdrop if desired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ src/temp
 dist
 node_modules
 test-ledger
+.env*

--- a/README.md
+++ b/README.md
@@ -335,14 +335,17 @@ interface initializeKeypairOptions {
   airdropAmount?: number;
   minimumBalance?: number;
   keypairPath?: string;
+  requestAirdropIfRequired?: boolean;
 }
 ```
 
 By default, the keypair will be retrieved from the `.env` file. If a `.env` file does not exist, this function will create one with a new keypair under the optional `envVariableName`.
 
-To load the keypair from the filesystem, pass in the `keypairPath`.
+To load the keypair from the filesystem, pass in the `keypairPath`. When set, loading a keypair from the filesystem will take precedence over loading from the `.env` file.
 
 After the keypair has been loaded, it will check the account's balance. If the balance is below the `minimumBalance`, it will airdrop the account `airdropAmount`.
+
+After the keypair has been loaded, you can skip the airdrop on low balance by setting `requestAirdropIfRequired` to `false`.
 
 To initialize a keypair from the `.env` file, and airdrop it 1 sol if it's beneath 0.5 sol:
 

--- a/README.md
+++ b/README.md
@@ -332,10 +332,9 @@ How the keypair is initialized is dependant on the `initializeKeypairOptions`:
 interface initializeKeypairOptions {
   envFileName?: string;
   envVariableName?: string;
-  airdropAmount?: number;
+  airdropAmount?: number | null;
   minimumBalance?: number;
   keypairPath?: string;
-  requestAirdropIfRequired?: boolean;
 }
 ```
 
@@ -345,7 +344,7 @@ To load the keypair from the filesystem, pass in the `keypairPath`. When set, lo
 
 After the keypair has been loaded, it will check the account's balance. If the balance is below the `minimumBalance`, it will airdrop the account `airdropAmount`.
 
-After the keypair has been loaded, you can skip the airdrop on low balance by setting `requestAirdropIfRequired` to `false`.
+After the keypair has been loaded, you can skip the airdrop on low balance by setting `airdropAmount` to `0` or `null`.
 
 To initialize a keypair from the `.env` file, and airdrop it 1 sol if it's beneath 0.5 sol:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,11 +216,11 @@ export const initializeKeypair = async (
   options?: InitializeKeypairOptions,
 ): Promise<Keypair> => {
   let {
+    keypairPath,
     envFileName,
     envVariableName = DEFAULT_ENV_KEYPAIR_VARIABLE_NAME,
-    airdropAmount,
-    minimumBalance,
-    keypairPath,
+    airdropAmount = DEFAULT_AIRDROP_AMOUNT,
+    minimumBalance = DEFAULT_MINIMUM_BALANCE,
   } = options || {};
 
   let keypair: Keypair;
@@ -238,8 +238,8 @@ export const initializeKeypair = async (
     await airdropIfRequired(
       connection,
       keypair.publicKey,
-      airdropAmount || DEFAULT_AIRDROP_AMOUNT,
-      minimumBalance || DEFAULT_MINIMUM_BALANCE,
+      airdropAmount,
+      minimumBalance,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,7 @@ export interface InitializeKeypairOptions {
   airdropAmount?: number;
   minimumBalance?: number;
   keypairPath?: string;
+  requestAirdropIfRequired?: boolean;
 }
 
 export const initializeKeypair = async (
@@ -217,14 +218,14 @@ export const initializeKeypair = async (
 ): Promise<Keypair> => {
   let {
     envFileName,
-    envVariableName,
+    envVariableName = DEFAULT_ENV_KEYPAIR_VARIABLE_NAME,
     airdropAmount,
     minimumBalance,
     keypairPath,
+    requestAirdropIfRequired = true,
   } = options || {};
 
   let keypair: Keypair;
-  envVariableName = envVariableName || DEFAULT_ENV_KEYPAIR_VARIABLE_NAME;
 
   if (keypairPath) {
     keypair = await getKeypairFromFile(keypairPath);
@@ -235,12 +236,14 @@ export const initializeKeypair = async (
     await addKeypairToEnvFile(keypair, envVariableName, envFileName);
   }
 
-  await airdropIfRequired(
-    connection,
-    keypair.publicKey,
-    airdropAmount || DEFAULT_AIRDROP_AMOUNT,
-    minimumBalance || DEFAULT_MINIMUM_BALANCE,
-  );
+  if (requestAirdropIfRequired) {
+    await airdropIfRequired(
+      connection,
+      keypair.publicKey,
+      airdropAmount || DEFAULT_AIRDROP_AMOUNT,
+      minimumBalance || DEFAULT_MINIMUM_BALANCE,
+    );
+  }
 
   return keypair;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,10 +206,9 @@ export const addKeypairToEnvFile = async (
 export interface InitializeKeypairOptions {
   envFileName?: string;
   envVariableName?: string;
-  airdropAmount?: number;
+  airdropAmount?: number | null;
   minimumBalance?: number;
   keypairPath?: string;
-  requestAirdropIfRequired?: boolean;
 }
 
 export const initializeKeypair = async (
@@ -222,7 +221,6 @@ export const initializeKeypair = async (
     airdropAmount,
     minimumBalance,
     keypairPath,
-    requestAirdropIfRequired = true,
   } = options || {};
 
   let keypair: Keypair;
@@ -236,7 +234,7 @@ export const initializeKeypair = async (
     await addKeypairToEnvFile(keypair, envVariableName, envFileName);
   }
 
-  if (requestAirdropIfRequired) {
+  if (!!airdropAmount) {
     await airdropIfRequired(
       connection,
       keypair.publicKey,


### PR DESCRIPTION
- Add the ability to initialize a keypair and skip the `airdropIfRequired` call when not desired
- updated the readme to clarify initializing a keypair from the filesystem will take precedence over the env variable when both are set