### PR TITLE
feat: save address to env file too

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,10 @@ export const addKeypairToEnvFile = async (
     throw new Error(`'${variableName}' already exists in env file.`);
   }
   const secretKeyString = keypairToSecretKeyJSON(keypair);
-  await appendFile(envFileName, `\n${variableName}=${secretKeyString}`);
+  await appendFile(
+    envFileName,
+    `\n# Solana Address: ${keypair.publicKey.toBase58()}\n${variableName}=${secretKeyString}`,
+  );
 };
 
 export interface InitializeKeypairOptions {


### PR DESCRIPTION
Updated the `addKeypairToEnvFile` function to also add a comment to the env file with the pubkey address that was saved