### PR TITLE
getCustomErrorMessage: Keep unknown errors.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -70,6 +70,17 @@ describe(`getCustomErrorMessage`, () => {
     );
     assert.equal(errorMessage, "This token mint cannot freeze accounts");
   });
+
+  test("getCustomErrorMessage() keeps unknown messages intact", () => {
+    const customErrors = [
+      "Lamport balance below rent-exempt threshold",
+      "Insufficient funds",
+    ];
+
+    const originalError = "An error unrelated to token transfer";
+    const errorMessage = getCustomErrorMessage(customErrors, originalError);
+    assert.equal(errorMessage, originalError);
+  });
 });
 
 describe("getKeypairFromFile", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,18 +69,22 @@ export const keypairToSecretKeyJSON = (keypair: Keypair): string => {
 export const getCustomErrorMessage = (
   possibleProgramErrors: Array<string>,
   errorMessage: string,
-): string | null => {
+): string => {
   const customErrorExpression =
     /.*custom program error: 0x(?<errorNumber>[0-9abcdef]+)/;
 
   let match = customErrorExpression.exec(errorMessage);
   const errorNumberFound = match?.groups?.errorNumber;
   if (!errorNumberFound) {
-    return null;
+    return errorMessage;
   }
   // errorNumberFound is a base16 string
   const errorNumber = parseInt(errorNumberFound, 16);
-  return possibleProgramErrors[errorNumber] || null;
+  const customMessage = possibleProgramErrors[errorNumber];
+
+  return customMessage != undefined && customMessage != null
+    ? customMessage
+    : errorMessage;
 };
 
 const encodeURL = (baseUrl: string, searchParams: Record<string, string>) => {


### PR DESCRIPTION
While `null` is more indicative, it seems more practical to return the original error.  The most common use case is to show the error to the user.  Returning `null` either loses useful information, or makes the usage more cumbersome, requiring additional checks at each call site.