### PR TITLE
Add makeTokenMint(), docs and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5
+
+- Add `makeTokenMint()`
+
 ## 2.4
 
 - Add `createAccountsMintsAndTokenAccounts()`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Parameters
   `freezeAuthority`: PublicKey (optional) - public key of the freeze account, default to `null`
 
 ```typescript
-const signature = await makeTokenMint(
+const mintAddress = await makeTokenMint(
   connection,
   mintAuthority,
   "Unit test token",

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The `helpers` package contains Solana helper functions, for use in the browser and/or node.js, [made by the Solana Foundation Developer Ecosystem team](https://youtu.be/zvQIa68ObK8?t=319) and our friends at [Anza](https://anza.xyz), [Turbin3](https://turbin3.com/), [Unboxed Software](https://beunboxed.com/), and [StarAtlas](https://staratlas.com/).
 
-Eventually, most of these will end up in `@solana/web3.js`.
-
 ## What can I do with this module?
 
 [Make multiple keypairs at once](#make-multiple-keypairs-at-once)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Eventually, most of these will end up in `@solana/web3.js`.
 
 [Make multiple keypairs at once](#make-multiple-keypairs-at-once)
 
+[Make a token mint with metadata](#make-a-token-with-metadata)
+
 [Create multiple accounts with balances of different tokens in a single step](#create-users-mints-and-token-accounts-in-a-single-step)
 
 [Resolve a custom error message](#resolve-a-custom-error-message)
@@ -54,6 +56,35 @@ In some situations - like making tests for your onchain programs - you might nee
 
 ```typescript
 const [sender, recipient] = makeKeypairs(2);
+```
+
+### Make a token mint with metadata
+
+The `makeTokenMint` makes a new token mint. A token mint is effectively the factory that produces token of a particular type. So if you want to make a new token, this is the right function for you!
+
+Unlike older tools, the function uses Token Extensions Metadata and Metadata Pointer to put all metadata into the Mint Account, without needing an external Metadata account. If you don't know what that means, just know that things are simpler than they used to be!
+
+Parameters
+
+- `connection`: Connection
+- `mintAuthority`: Keypair of the account that can make new tokens
+- `name`: string, name of the token
+- `symbol`: string, like a ticker symbol. Usually in all-caps.
+- `decimals`: number, how many decimal places the token has
+- `uri`: string, URI to an file containing
+- `additionalMetadata`: Array<[string, string]> (optional), an array of key/value pairs for additional metadata.
+- `updateAuthority`: PublicKey (optional) - public key of the account that can update the token.
+  `freezeAuthority`: PublicKey (optional) - public key of the freeze account, default to `null`
+
+```typescript
+const signature = await makeTokenMint(
+  connection,
+  mintAuthority,
+  "Unit test token",
+  "TEST",
+  9,
+  "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/sample-token-metadata.json",
+);
 ```
 
 ### Create users, mints and token accounts in a single step

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Unlike older tools, the function uses Token Extensions Metadata and Metadata Poi
 
 Parameters
 
-- `connection`: Connection
-- `mintAuthority`: Keypair of the account that can make new tokens
-- `name`: string, name of the token
+- `connection`: Connection.
+- `mintAuthority`: Keypair of the account that can make new tokens.
+- `name`: string, name of the token.
 - `symbol`: string, like a ticker symbol. Usually in all-caps.
-- `decimals`: number, how many decimal places the token has
-- `uri`: string, URI to an file containing
-- `additionalMetadata`: Array<[string, string]> (optional), an array of key/value pairs for additional metadata.
+- `decimals`: number, how many decimal places the new token will have.
+- `uri`: string, URI to a JSON file containing at minimum a value for `image`.
+- `additionalMetadata`: additional metadata as either `Record<string, string>` or `Array<[string, string]>`(optional).
 - `updateAuthority`: PublicKey (optional) - public key of the account that can update the token.
   `freezeAuthority`: PublicKey (optional) - public key of the freeze account, default to `null`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/helpers",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.4.8",
+        "@solana/spl-token-metadata": "^0.1.4",
         "@solana/web3.js": "^1.95.2",
         "bs58": "^6.0.0",
         "dotenv": "^16.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Solana helper functions",
   "main": "dist/index.js",
   "private": false,
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@solana/spl-token": "^0.4.8",
+    "@solana/spl-token-metadata": "^0.1.4",
     "@solana/web3.js": "^1.95.2",
     "bs58": "^6.0.0",
     "dotenv": "^16.4.5"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   getLogs,
   getSimulationComputeUnits,
   createAccountsMintsAndTokenAccounts,
+  makeTokenMint,
 } from "./index";
 import {
   Connection,
@@ -498,6 +499,30 @@ describe("getSimulationComputeUnits", () => {
     // TODO: it would be useful to have a breakdown of exactly how 3888 CUs is calculated
     // also worth reviewing why memo program seems to use so many CUs.
     assert.equal(computeUnitsSendSolAndSayThanks, 3888);
+  });
+});
+
+describe("makeTokenMint", () => {
+  test("makeTokenMint works", async () => {
+    const mintAuthority = Keypair.generate();
+    const connection = new Connection(LOCALHOST);
+    await airdropIfRequired(
+      connection,
+      mintAuthority.publicKey,
+      100 * LAMPORTS_PER_SOL,
+      1 * LAMPORTS_PER_SOL,
+    );
+
+    const signature = await makeTokenMint(
+      connection,
+      mintAuthority,
+      "Unit test token",
+      "TEST",
+      9,
+      "https://example.com",
+    );
+
+    assert.ok(signature);
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -513,7 +513,7 @@ describe("makeTokenMint", () => {
       1 * LAMPORTS_PER_SOL,
     );
 
-    const signature = await makeTokenMint(
+    const mintAddress = await makeTokenMint(
       connection,
       mintAuthority,
       "Unit test token",
@@ -522,7 +522,7 @@ describe("makeTokenMint", () => {
       "https://example.com",
     );
 
-    assert.ok(signature);
+    assert.ok(mintAddress);
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -515,13 +515,29 @@ describe("makeTokenMint", () => {
       1 * LAMPORTS_PER_SOL,
     );
 
+    const name = "Unit test token";
+    const symbol = "TEST";
+    const decimals = 9;
+    const uri = "https://example.com";
+    const additionalMetadata = {
+      shlerm: "frobular",
+      glerp: "flerpy",
+      gurperderp: "erpy",
+      nurmagerd: "flerpy",
+      zurp: "flerpy",
+      eruper: "flerpy",
+      zerperurperserp: "flerpy",
+      zherp: "flerpy",
+    };
+
     const mintAddress = await makeTokenMint(
       connection,
       mintAuthority,
-      "Unit test token",
-      "TEST",
-      9,
-      "https://example.com",
+      name,
+      symbol,
+      decimals,
+      uri,
+      additionalMetadata,
     );
 
     assert.ok(mintAddress);
@@ -539,10 +555,13 @@ describe("makeTokenMint", () => {
       tokenMetadata.updateAuthority?.toBase58(),
       mintAuthority.publicKey.toBase58(),
     );
-    assert.equal(tokenMetadata.name, "Unit test token");
-    assert.equal(tokenMetadata.symbol, "TEST");
-    assert.equal(tokenMetadata.uri, "https://example.com");
-    assert.deepEqual(tokenMetadata.additionalMetadata, []);
+    assert.equal(tokenMetadata.name, name);
+    assert.equal(tokenMetadata.symbol, symbol);
+    assert.equal(tokenMetadata.uri, uri);
+    assert.deepEqual(
+      tokenMetadata.additionalMetadata,
+      Object.entries(additionalMetadata),
+    );
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
   SystemProgram,
   Signer,
   Commitment,
+  Transaction,
+  sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import base58 from "bs58";
 import {
@@ -26,7 +28,15 @@ import {
   getAssociatedTokenAddressSync,
   getMinimumBalanceForRentExemptMint,
   TOKEN_2022_PROGRAM_ID,
+  createInitializeMetadataPointerInstruction,
+  createInitializeMintInstruction,
+  ExtensionType,
+  getMintLen,
+  LENGTH_SIZE,
+  TYPE_SIZE,
 } from "@solana/spl-token";
+import type { TokenMetadata } from "@solana/spl-token-metadata";
+import { createInitializeInstruction, pack } from "@solana/spl-token-metadata";
 
 // Default value from Solana CLI
 const DEFAULT_FILEPATH = "~/.config/solana/id.json";
@@ -539,4 +549,78 @@ export const createAccountsMintsAndTokenAccounts = async (
     mints,
     tokenAccounts,
   };
+};
+
+export const makeTokenMint = async (
+  connection: Connection,
+  mintAuthority: Keypair,
+  name: string,
+  symbol: string,
+  decimals: number,
+  uri: string,
+  additionalMetadata: Array<[string, string]> = [],
+  updateAuthority: PublicKey = mintAuthority.publicKey,
+  freezeAuthority: PublicKey | null = null,
+) => {
+  const mint = Keypair.generate();
+
+  const metadata: TokenMetadata = {
+    mint: mint.publicKey,
+    name,
+    symbol,
+    uri,
+    additionalMetadata,
+  };
+
+  // Work out how much SOL we need to store our Token
+  const mintLength = getMintLen([ExtensionType.MetadataPointer]);
+  const metadataLength = TYPE_SIZE + LENGTH_SIZE + pack(metadata).length;
+  const mintLamports = await connection.getMinimumBalanceForRentExemption(
+    mintLength + metadataLength,
+  );
+
+  const mintTransaction = new Transaction().add(
+    // Create Account
+    SystemProgram.createAccount({
+      fromPubkey: mintAuthority.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space: mintLength,
+      lamports: mintLamports,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    // Initialize metadata pointer (so the mint points to itself for metadata)
+    createInitializeMetadataPointerInstruction(
+      mint.publicKey,
+      mintAuthority.publicKey,
+      mint.publicKey,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    // Initialize mint
+    createInitializeMintInstruction(
+      mint.publicKey,
+      decimals,
+      mintAuthority.publicKey,
+      freezeAuthority,
+      TOKEN_2022_PROGRAM_ID,
+    ),
+    // Initialize
+    createInitializeInstruction({
+      programId: TOKEN_2022_PROGRAM_ID,
+      mint: mint.publicKey,
+      metadata: mint.publicKey,
+      name: metadata.name,
+      symbol: metadata.symbol,
+      uri: metadata.uri,
+      mintAuthority: mintAuthority.publicKey,
+      updateAuthority: updateAuthority,
+    }),
+  );
+
+  const signature = await sendAndConfirmTransaction(
+    connection,
+    mintTransaction,
+    [mintAuthority, mint],
+  );
+
+  return signature;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -622,5 +622,6 @@ export const makeTokenMint = async (
     [mintAuthority, mint],
   );
 
-  return signature;
+
+  return mint.publicKey;
 };


### PR DESCRIPTION
Currently to make a token mint (with metadata) it's [really damn long](https://github.com/solana-labs/solana-program-library/blob/master/token/js/examples/metadata.ts). Add a little wrapper function to do it in one line.