### PR TITLE
Emit type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/helpers",
-      "version": "2.5.0",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.4.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2022",
     "moduleResolution": "Bundler",
     "module": "ES2022",
+    "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
This PR configures the TypeScript compiler to generate type definitions, so that TypeScript projects can use this library without type errors.