### PR TITLE
added cjs distribution command and tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/helpers",
-      "version": "2.5.0",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,32 @@
   "name": "@solana-developers/helpers",
   "version": "2.5.2",
   "description": "Solana helper functions",
-  "main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "type": "module",
   "private": false,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./node": {
+      "import": "./dist/esm/node.js",
+      "require": "./dist/cjs/node.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "clean": "rm -rf dist",
-    "test": "esrun src/index.test.ts"
+    "test": "esrun src/index.test.ts",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "solana",
@@ -24,7 +43,8 @@
     "Nick Frostbutter",
     "John Liu",
     "Steven Luscher",
-    "Christian Krueger"
+    "Christian Krueger",
+    "Ayush Chauhan"
   ],
   "license": "MIT",
   "dependencies": {

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,20 @@
-// See https://aka.ms/tsconfig
 {
   "compilerOptions": {
-    "outDir": "dist",
-    "target": "es2022",
-    "moduleResolution": "Bundler",
-    "module": "ES2022",
+    "target": "ES2018",
+    "lib": ["ES2018", "DOM"],
+    "moduleResolution": "node",
+    "outDir": "./dist/esm",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "isolatedModules": true
   },
-  "include": ["src"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Problem
- current package only supports ECMAScript Modules (ESM).
- devs relying on CommonJS (CJS) cannot utilize the package.
- limits compatibility with various Node.js environments and tools.

Changes

- Added CJS distribution to the existing ESM-only package.
- existing ESM functionality is there.
- improved overall package accessibility and usability.