### PR TITLE
fix .cjs and package.json in distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,10 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.ts",
+        "types": "./dist/types/index.d.ts",
         "default": "./dist/esm/index.js"
       },
       "require": {
-        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.cjs"
       }
     }
@@ -24,9 +23,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run build:esm && npm run build:cjs",
-    "build:esm": "tsc -p tsconfig.json",
+    "prebuild": "npm run clean",
+    "build": "npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:types": "tsc -p tsconfig.types.json",
     "postbuild": "node post-build.mjs",
     "clean": "rm -rf dist",
     "test": "cd tests && npm run test",

--- a/package.json
+++ b/package.json
@@ -2,29 +2,32 @@
   "name": "@solana-developers/helpers",
   "version": "2.5.4",
   "description": "Solana helper functions",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
   "type": "module",
-  "private": false,
+  "main": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./node": {
-      "import": "./dist/esm/node.js",
-      "require": "./dist/cjs/node.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
+  "private": false,
+  "sideEffects": false,
   "files": [
     "dist"
   ],
-  "sideEffects": false,
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
+    "postbuild": "node post-build.mjs",
     "clean": "rm -rf dist",
     "test": "cd tests && npm run test",
     "test:ci": "cd tests && npm run test:ci"

--- a/post-build.mjs
+++ b/post-build.mjs
@@ -1,3 +1,9 @@
+// In some cases, where you have { type: module } in package.json at the root
+// We will workaround builds manually, since we aren't using any bundler
+// tsc is missing extensions with esm exports
+// and tsc doesn't export .cjs hence, index.js won't be read as cjs in cjs distribution
+// See https://github.com/microsoft/TypeScript/issues/54593
+
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/post-build.mjs
+++ b/post-build.mjs
@@ -1,0 +1,61 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CJS_DIR = path.join(__dirname, 'dist', 'cjs');
+const ESM_DIR = path.join(__dirname, 'dist', 'esm');
+
+async function createPackageJson(dir, type) {
+  const content = JSON.stringify({ type }, null, 2);
+  await fs.writeFile(path.join(dir, 'package.json'), content);
+  console.log(`Created package.json in ${dir}`);
+}
+
+async function renameIndexFile() {
+  const oldPath = path.join(CJS_DIR, 'index.js');
+  const newPath = path.join(CJS_DIR, 'index.cjs');
+  await fs.rename(oldPath, newPath);
+  console.log('Renamed CJS index file to index.cjs');
+}
+
+async function processEsmFiles(dir) {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await processEsmFiles(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.js')) {
+        let content = await fs.readFile(fullPath, 'utf8');
+        
+        // Add .js extension to import statements
+        content = content.replace(/from\s+['"](\.[^'"]+)['"]/g, "from '$1.js'");
+        
+        // Add .js extension to export statements
+        content = content.replace(/export\s+\*\s+from\s+['"](\.[^'"]+)['"]/g, "export * from '$1.js'");
+        
+        await fs.writeFile(fullPath, content);
+        console.log(`Processed ESM file: ${fullPath}`);
+      }
+    }
+  }
+
+async function postbuild() {
+  try {
+    // Create package.json files
+    await createPackageJson(CJS_DIR, 'commonjs');
+    await createPackageJson(ESM_DIR, 'module');
+
+    // Rename index.js to index.cjs in CJS directory
+    await renameIndexFile();
+
+    // Process ESM files to add .js extensions
+    await processEsmFiles(ESM_DIR);
+
+    console.log('Postbuild completed successfully!');
+  } catch (error) {
+    console.error('Postbuild failed:', error);
+    process.exit(1);
+  }
+}
+
+postbuild();

--- a/post-build.mjs
+++ b/post-build.mjs
@@ -1,19 +1,20 @@
-import { promises as fs } from 'fs';
-import path from 'path';
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const CJS_DIR = path.join(__dirname, 'dist', 'cjs');
-const ESM_DIR = path.join(__dirname, 'dist', 'esm');
+const CJS_DIR = join(__dirname, 'dist', 'cjs');
+const ESM_DIR = join(__dirname, 'dist', 'esm');
 
 async function createPackageJson(dir, type) {
   const content = JSON.stringify({ type }, null, 2);
-  await fs.writeFile(path.join(dir, 'package.json'), content);
+  await fs.writeFile(join(dir, 'package.json'), content);
   console.log(`Created package.json in ${dir}`);
 }
 
 async function renameIndexFile() {
-  const oldPath = path.join(CJS_DIR, 'index.js');
-  const newPath = path.join(CJS_DIR, 'index.cjs');
+  const oldPath = join(CJS_DIR, 'index.js');
+  const newPath = join(CJS_DIR, 'index.cjs');
   await fs.rename(oldPath, newPath);
   console.log('Renamed CJS index file to index.cjs');
 }
@@ -21,7 +22,7 @@ async function renameIndexFile() {
 async function processEsmFiles(dir) {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
+      const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {
         await processEsmFiles(fullPath);
       } else if (entry.isFile() && entry.name.endsWith('.js')) {

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "outDir": "./dist/cjs",
+    "module": "ESNext",
+    "outDir": "./dist/esm",
     "sourceMap": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "module": "ESNext",
     "lib": ["ES2018", "DOM"],
     "moduleResolution": "node",
-    "outDir": "./dist/esm",
-    "rootDir": "./src",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true,
-    "declarationDir": "./dist/types",
-    "sourceMap": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
-    "preserveConstEnums": true
+    "preserveConstEnums": true,
+    "rootDir": "./src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2018",
+    "module": "ESNext",
     "lib": ["ES2018", "DOM"],
     "moduleResolution": "node",
     "outDir": "./dist/esm",
     "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "module": "ESNext",
-    "isolatedModules": true
+    "isolatedModules": true,
+    "preserveConstEnums": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "declarationMap": true,
+    "declarationDir": "./dist/types",
     "sourceMap": true,
     "strict": true,
     "skipLibCheck": true,

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types"
+  }
+}


### PR DESCRIPTION
## Problems

- CJS version of distribution is giving error for Node.JS
```
Error [ERR_REQUIRE_ESM]: require() of ES Module /project/workspace/node_modules/@solana-developers/helpers/dist/cjs/index.js from /project/workspace/index.js not supported.
/project/workspace/node_modules/@solana-developers/helpers/dist/cjs/index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename /project/workspace/node_modules/@solana-developers/helpers/dist/cjs/index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /project/workspace/node_modules/@solana-developers/helpers/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/project/workspace/index.js:1:26) {
  code: 'ERR_REQUIRE_ESM'
}
```

- ESM version of distribution is not getting recognised for Node.JS when executed with .mjs extension
- ESM Exports are not correct
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/project/workspace/node_modules/@solana-developers/helpers/dist/esm/lib/keypair' imported from /project/workspace/node_modules/@solana-developers/helpers/dist/esm/index.js
    at finalizeResolution (node:internal/modules/esm/resolve:265:11)
    at moduleResolve (node:internal/modules/esm/resolve:933:10)
    at defaultResolve (node:internal/modules/esm/resolve:1157:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:390:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:359:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:234:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
    at link (node:internal/modules/esm/module_job:86:36) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///project/workspace/node_modules/@solana-developers/helpers/dist/esm/lib/keypair'
}
```

## Solutions

- Add a `post-build.mjs` script to process files further that tsc isn't doing
- Add package.json in cjs and esm distributions at build step, (escaping fallback of package.json to default one)
- rename exports and imports with `.js` for esm builds
- Add types as a distribution folder
- Refactor tsconfig.json(s) to have non redundant ts declarations (exclude declarations from esm and cjs dists)