### PR TITLE
fix: 🐛 [object Object] error message fixed

### DIFF
--- a/src/lib/logs.ts
+++ b/src/lib/logs.ts
@@ -31,7 +31,7 @@ export const getErrorFromRPCResponse = (
       const errorKeys = Object.keys(error);
       if (errorKeys.length === 1) {
         if (errorKeys[0] !== "InstructionError") {
-          throw new Error(`Unknown RPC error: ${error}`);
+          throw new Error(`Unknown RPC error: ${JSON.stringify(error)}`);
         }
         // @ts-ignore due to missing typing information mentioned above.
         const instructionError = error["InstructionError"];


### PR DESCRIPTION
Fixed error message, that's thrown when rpc throws unknown error

```
// logs.ts
throw new Error(`Unknown RPC error: ${error}`);
// Bugged output
Error: Unknown RPC error: [object Object]
// Fixed output
Error: Unknown RPC error: {"InsufficientFundsForRent":{"account_index":0}}
```