### PR TITLE
Combine prepareCompute and Retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7
+
+- Added `sendTransaction()` to send transactions with compute unit optimization and automatic retries.
+- Removed `sendTransactionWithRetry()` as sendTransaction() is more convenient.
+
 ## 2.6
 
 - Added Transaction send helpers. `prepareTransactionWithCompute()` and `sendTransactionWithRetry()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.4.5"
       },
       "devDependencies": {
+        "@types/bn.js": "^5.1.6",
         "@types/node": "^20.16.1",
         "esbuild": "^0.23.1",
         "esbuild-register": "^3.6.0",
@@ -875,6 +876,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "bs58": "^6.0.0",
     "dotenv": "^16.4.5",
     "@coral-xyz/anchor": "^0.30.1"
-
   },
   "devDependencies": {
+    "@types/bn.js": "^5.1.6",
     "@types/node": "^20.16.1",
     "esbuild": "^0.23.1",
     "esbuild-register": "^3.6.0",

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -11,7 +11,6 @@ import {
   TransactionMessage,
   VersionedTransaction,
   Message,
-  MessageV0,
   MessageCompiledInstruction,
 } from "@solana/web3.js";
 import { getErrorFromRPCResponse } from "./logs";
@@ -22,8 +21,8 @@ import {
   EventParser,
   BorshAccountsCoder,
   BorshInstructionCoder,
-  BN,
 } from "@coral-xyz/anchor";
+import BN from "bn.js";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -703,12 +702,14 @@ export async function sendTransaction(
     });
   }
 
-  const hasComputeInstructions = transaction.instructions.some(ix => 
-    ix.programId.equals(ComputeBudgetProgram.programId)
+  const hasComputeInstructions = transaction.instructions.some((ix) =>
+    ix.programId.equals(ComputeBudgetProgram.programId),
   );
 
   if (hasComputeInstructions) {
-    console.log("Transaction already has compute instructions, skipping compute preparation"); 
+    console.log(
+      "Transaction already has compute instructions, skipping compute preparation",
+    );
     return sendTransactionWithRetry(connection, transaction, signers, {
       commitment,
       ...sendOptions,

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -207,6 +207,18 @@ export async function sendTransactionWithRetry(
     transaction.sign(...signers);
   }
 
+  if (transaction.recentBlockhash === undefined) {
+    console.log("No blockhash provided. Setting recent blockhash");
+    const { blockhash } = await connection.getLatestBlockhash(commitment);
+    transaction.recentBlockhash = blockhash;
+  }
+  if (transaction.feePayer === undefined) {
+    if (signers.length === 0) {
+      throw new Error("No signers or fee payer provided");
+    }
+    transaction.feePayer = signers[0].publicKey;
+  }
+
   onStatusUpdate?.({ status: "signed" });
 
   let signature: string | null = null;
@@ -623,4 +635,73 @@ function formatData(data: any): any {
     );
   }
   return data;
+}
+
+/**
+ * Sends a transaction with compute unit optimization and automatic retries
+ *
+ * @param connection - The Solana connection object
+ * @param transaction - The transaction to send
+ * @param signers - Array of signers needed for the transaction
+ * @param priorityFee - Priority fee in microLamports
+ * @param options - Optional configuration for retry mechanism and compute units
+ * @returns Promise that resolves to the transaction signature
+ *
+ * @example
+ * ```typescript
+ * const signature = await sendTransactionWithRetryAndPriorityFees(
+ *   connection,
+ *   transaction,
+ *   [payer],
+ *   1000,
+ *   {
+ *     computeUnitBuffer: { multiplier: 1.1 },
+ *     onStatusUpdate: (status) => console.log(status),
+ *   }
+ * );
+ * ```
+ */
+export async function sendTransactionWithRetryAndPriorityFees(
+  connection: Connection,
+  transaction: Transaction,
+  signers: Keypair[],
+  priorityFee: number = 10000,
+  options: SendTransactionOptions & {
+    computeUnitBuffer?: ComputeUnitBuffer;
+  } = {},
+): Promise<string> {
+  const {
+    computeUnitBuffer: userComputeBuffer, // Rename to make clear it's user provided
+    commitment = "confirmed",
+    ...sendOptions
+  } = options;
+
+  // Use user provided buffer or default to 1.1 multiplier
+  const computeUnitBuffer = userComputeBuffer ?? { multiplier: 1.1 };
+
+  if (transaction.recentBlockhash === undefined) {
+    console.log("No blockhash provided. Setting recent blockhash");
+    const { blockhash } = await connection.getLatestBlockhash(commitment);
+    transaction.recentBlockhash = blockhash;
+  }
+  if (transaction.feePayer === undefined) {
+    if (signers.length === 0) {
+      throw new Error("No signers or fee payer provided");
+    }
+    transaction.feePayer = signers[0].publicKey;
+  }
+
+  await prepareTransactionWithCompute(
+    connection,
+    transaction,
+    transaction.feePayer,
+    priorityFee,
+    computeUnitBuffer,
+    commitment,
+  );
+
+  return sendTransactionWithRetry(connection, transaction, signers, {
+    commitment,
+    ...sendOptions,
+  });
 }

--- a/tests/src/transaction.test.ts
+++ b/tests/src/transaction.test.ts
@@ -14,8 +14,7 @@ import {
   confirmTransaction,
   getSimulationComputeUnits,
   prepareTransactionWithCompute,
-  sendTransactionWithRetry,
-  sendTransactionWithRetryAndPriorityFees,
+  sendTransaction,
 } from "../../src";
 import { sendAndConfirmTransaction } from "@solana/web3.js";
 import assert from "node:assert";
@@ -101,7 +100,7 @@ describe("getSimulationComputeUnits", () => {
 });
 
 describe("Transaction utilities", () => {
-  test("sendTransactionWithRetry should send and confirm a transaction", async () => {
+  test("sendTransaction without priority fee should send and confirm a transaction", async () => {
     const connection = new Connection(LOCALHOST);
     const sender = Keypair.generate();
     await airdropIfRequired(
@@ -126,10 +125,11 @@ describe("Transaction utilities", () => {
     transaction.feePayer = sender.publicKey;
 
     const statusUpdates: any[] = [];
-    const signature = await sendTransactionWithRetry(
+    const signature = await sendTransaction(
       connection,
       transaction,
       [sender],
+      0,
       {
         onStatusUpdate: (status) => {
           statusUpdates.push(status);
@@ -195,7 +195,7 @@ describe("Transaction utilities", () => {
     });
   });
 
-  test("sendTransactionWithRetryAndPriorityFees should prepare and send a transaction", async () => {
+  test("sendTransaction should prepare and send a transaction and add priority fee instructions", async () => {
     const connection = new Connection(LOCALHOST);
     const sender = Keypair.generate();
     await airdropIfRequired(
@@ -215,7 +215,7 @@ describe("Transaction utilities", () => {
     );
 
     const statusUpdates: any[] = [];
-    const signature = await sendTransactionWithRetryAndPriorityFees(
+    const signature = await sendTransaction(
       connection,
       transaction,
       [sender],


### PR DESCRIPTION
- Added a new helper to make sending transactions only one line: sendTransactionWithRetryAndPriorityFees

Examples usage:
 
```ts
    const initTransaction = await program.methods.initialize().transaction();

    await sendTransaction(
      connection,
      initTransaction,
      [keyPair],
      10000 // priority fee
    );
```