### PR TITLE
fix node imports for anchor functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.7
 
 - Added `sendTransaction()` to send transactions with compute unit optimization and automatic retries.
-- Removed `sendTransactionWithRetry()` as sendTransaction() is more convenient.
+- Removed `sendTransactionWithRetry()` as `sendTransaction()` is more convenient.
+- Fixed the node specific imports for the Anchor transaction helpers
 
 ## 2.6
 

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -23,8 +23,6 @@ import {
   BorshInstructionCoder,
 } from "@coral-xyz/anchor";
 import BN from "bn.js";
-import * as fs from "fs";
-import * as path from "path";
 
 export const confirmTransaction = async (
   connection: Connection,
@@ -387,6 +385,9 @@ export async function getIdlParsedAccountData<T = any>(
   accountAddress: PublicKey,
   connection?: Connection,
 ): Promise<T> {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
   // Load and parse IDL file
   const idlFile = fs.readFileSync(path.resolve(idlPath), "utf8");
   const idl = JSON.parse(idlFile) as Idl;
@@ -426,6 +427,9 @@ export async function parseAnchorTransactionEvents(
     data: any;
   }>
 > {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
   const idlFile = fs.readFileSync(path.resolve(idlPath), "utf8");
   const idl = JSON.parse(idlFile) as Idl;
 
@@ -493,6 +497,9 @@ export async function decodeAnchorTransaction(
   signature: string,
   connection?: Connection,
 ): Promise<DecodedTransaction> {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
   const idlFile = fs.readFileSync(path.resolve(idlPath), "utf8");
   const idl = JSON.parse(idlFile) as Idl;
 


### PR DESCRIPTION
the recently added anchor helper functions add the node specific imports for `fs` and `path` to the top level imports. this may result in browser's attempting to call any of the transaction helpers to fail.

fixed by converting them to local imports inside the functions that call them