### PR TITLE
Fix category headings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ The `helpers` package contains Solana helper functions, for use in the browser a
 
 ## What can I do with this module?
 
-Account & Keypair Management:
+### Account & Keypair Management:
+
 [Make multiple keypairs at once](#make-multiple-keypairs-at-once)
 
 [Get a keypair from a keypair file](#get-a-keypair-from-a-keypair-file)
@@ -15,12 +16,14 @@ Account & Keypair Management:
 
 [Load or create a keypair and airdrop to it if needed](#load-or-create-a-keypair-and-airdrop-to-it-if-needed)
 
-Token Operations:
+### Token Operations:
+
 [Make a token mint with metadata](#make-a-token-mint-with-metadata)
 
 [Create multiple accounts with balances of different tokens in a single step](#create-users-mints-and-token-accounts-in-a-single-step)
 
-Transaction & Compute Management:
+### Transaction & Compute Management:
+
 [Confirm a transaction](#confirm-a-transaction)
 
 [Get the logs for a transaction](#get-the-logs-for-a-transaction)
@@ -29,12 +32,13 @@ Transaction & Compute Management:
 
 [Get an airdrop if your balance is below some amount](#get-an-airdrop-if-your-balance-is-below-some-amount)
 
-Error Handling & Utilities:
+### Error Handling & Utilities:
 [Resolve a custom error message](#resolve-a-custom-error-message)
 
 [Get a Solana Explorer link for a transaction, address, or block](#get-a-solana-explorer-link-for-a-transaction-address-or-block)
 
-Anchor Program Interaction:
+### Anchor Program Interaction:
+
 [Parse account data with IDL](#parse-account-data-with-idl)
 
 [Parse transaction events](#parse-transaction-events)


### PR DESCRIPTION
Currently the category headings in the markdown look a little wonky (see below). This PR [fixes them](https://github.com/solana-developers/helpers/pull/76/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5):

![Screenshot 2025-02-07 at 4 04 14 PM](https://github.com/user-attachments/assets/cc73246e-35e5-411d-9a5c-abc730f70153)
