### PR TITLE
Support legacy IDL + Versioned Transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.8
+
+- Added `sendVersionedTransaction()` to send a versioned transaction with lookup tables. Also adds priority fee support.
+- Added `createLookupTable()` to easily create a lookup table and extend it with additional addresses
+- Added `getIDlByProgramId()` to fetch an IDL from a program on-chain
+- Added `getIDlByIdlPath()` to parse an IDL from a local file path
+- Added `getIdlParsedAccountData()` to parse account data using an IDL
+- Added `parseAnchorTransactionEvents()` to parse anchor transaction events using an IDL
+- Added `decodeAnchorTransaction()` to decode a transaction completely using an IDL
+- Fixed account data parsing in `decodeAnchorTransaction()`
+
 ## 2.7
 
 - Added `sendTransaction()` to send transactions with compute unit optimization and automatic retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - Added `sendVersionedTransaction()` to send a versioned transaction with lookup tables. Also adds priority fee support.
 - Added `createLookupTable()` to easily create a lookup table and extend it with additional addresses
-- Added `getIDlByProgramId()` to fetch an IDL from a program on-chain
-- Added `getIDlByIdlPath()` to parse an IDL from a local file path
+- Added `getIdlByProgramId()` to fetch an IDL from a program on-chain
+- Added `getIdlByPath()` to parse an IDL from a local file path
 - Added `getIdlParsedAccountData()` to parse account data using an IDL
 - Added `parseAnchorTransactionEvents()` to parse anchor transaction events using an IDL
 - Added `decodeAnchorTransaction()` to decode a transaction completely using an IDL

--- a/README.md
+++ b/README.md
@@ -645,13 +645,13 @@ These utilities help with:
 Get an IDL from a local file:
 
 ```typescript
-const idl = await getIDlbyPath("./idl/program.json");
+const idl = await getIdlByPath("./idl/program.json");
 ```
 
 Or fetch it from the chain:
 
 ```typescript
-const idl = await getIDlByProgramId(
+const idl = await getIdlByProgramId(
   new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
   connection,
 );
@@ -662,7 +662,7 @@ const idl = await getIDlByProgramId(
 Usage:
 
 ```typescript
-const idl = await getIDlByProgramId(programId, connection);
+const idl = await getIdlByProgramId(programId, connection);
 const data = await getIdlParsedAccountData(
   idl,
   "counter",
@@ -680,7 +680,7 @@ Fetches and parses an account's data using an Anchor IDL file. This is useful wh
 Usage:
 
 ```typescript
-const idl = await getIDlbyPath("./idl/program.json");
+const idl = await getIdlByPath("./idl/program.json");
 const events = await parseAnchorTransactionEvents(idl, signature, connection);
 
 // Events will be an array of:
@@ -697,7 +697,7 @@ Parses all Anchor events emitted in a transaction. This helps you track and veri
 Usage:
 
 ```typescript
-const idl = await getIDlByProgramId(programId, connection);
+const idl = await getIdlByProgramId(programId, connection);
 const decoded = await decodeAnchorTransaction(idl, signature, connection);
 
 // Print human-readable format

--- a/README.md
+++ b/README.md
@@ -597,12 +597,12 @@ const signature = await sendVersionedTransaction(
 );
 ```
 
-#### `CreateLookupTable`
+#### `createLookupTable`
 
 Creates a new address lookup table and extends it with additional addresses.
 
 ```typescript
-async function CreateLookupTable(
+async function createLookupTable(
   connection: Connection,
   sender: Keypair,
   additionalAddresses: PublicKey[],
@@ -613,7 +613,7 @@ async function CreateLookupTable(
 Example:
 
 ```typescript
-const [lookupTableAddress, lookupTableAccount] = await CreateLookupTable(
+const [lookupTableAddress, lookupTableAccount] = await createLookupTable(
   connection,
   payer,
   [account1.publicKey, account2.publicKey, account3.publicKey],

--- a/README.md
+++ b/README.md
@@ -327,6 +327,33 @@ const units = await getSimulationComputeUnits(
 
 You can then use `ComputeBudgetProgram.setComputeUnitLimit({ units })` as the first instruction in your transaction. See [How to Request Optimal Compute Budget](https://solana.com/developers/guides/advanced/how-to-request-optimal-compute) for more information on compute units.
 
+### `addComputeInstructions`
+
+Adds compute unit instructions for a transaction if they don't already exist:
+
+```typescript
+const updatedInstructions = await addComputeInstructions(
+  connection,
+  instructions,
+  lookupTables,
+  payer.publicKey,
+  10000, // priority fee default 10000 microLamports
+  { multiplier: 1.1 }, // compute unit buffer default adds 10%
+);
+
+// Returns instructions array with:
+// 1. setComputeUnitPrice instruction (if not present)
+// 2. setComputeUnitLimit instruction based on simulation (if not present)
+// The limit is calculated by simulating the transaction and adding the specified buffer
+```
+
+This function:
+
+1. Adds priority fee instruction if not present
+2. Simulates transaction to determine required compute units
+3. Adds compute unit limit instruction with buffer
+4. Returns the updated instructions array
+
 ## node.js specific helpers
 
 ### Get a keypair from a keypair file

--- a/README.md
+++ b/README.md
@@ -541,29 +541,6 @@ For RPC providers that support priority fees:
 - Triton: see their [priority fee API](https://docs.triton.one/chains/solana/improved-priority-fees-api)
 - Quicknode: see their [priority fee estimation](https://www.quicknode.com/docs/solana/qn_estimatePriorityFees)
 
-#### `prepareTransactionWithCompute`
-
-If you need more control, you can prepare compute units separately:
-
-```typescript
-await prepareTransactionWithCompute(
-  connection,
-  transaction,
-  payer.publicKey,
-  10000, // priority fee
-  {
-    multiplier: 1.1, // add 10% buffer
-    fixed: 100, // add fixed amount of CUs
-  },
-);
-```
-
-This will:
-
-1. Simulate the transaction to determine required compute units
-2. Add compute budget instructions for both price and unit limit
-3. Apply any specified compute unit buffers
-
 #### `sendVersionedTransaction`
 
 Sends a versioned transaction with compute unit optimization and automatic retries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@solana/web3.js": "^1.98.0",
         "bn.js": "^5.2.1",
         "bs58": "^6.0.0",
-        "change-case": "^5.4.4",
         "dotenv": "^16.4.5"
       },
       "devDependencies": {
@@ -1093,11 +1092,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="
     },
     "node_modules/commander": {
       "version": "2.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.5.6",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/helpers",
-      "version": "2.5.6",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",
         "@solana/spl-token": "^0.4.8",
         "@solana/spl-token-metadata": "^0.1.4",
         "@solana/web3.js": "^1.98.0",
+        "bn.js": "^5.2.1",
         "bs58": "^6.0.0",
+        "change-case": "^5.4.4",
         "dotenv": "^16.4.5"
       },
       "devDependencies": {
@@ -1091,6 +1093,11 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="
     },
     "node_modules/commander": {
       "version": "2.20.3",

--- a/package.json
+++ b/package.json
@@ -60,12 +60,14 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@coral-xyz/anchor": "^0.30.1",
     "@solana/spl-token": "^0.4.8",
     "@solana/spl-token-metadata": "^0.1.4",
     "@solana/web3.js": "^1.98.0",
+    "bn.js": "^5.2.1",
     "bs58": "^6.0.0",
-    "dotenv": "^16.4.5",
-    "@coral-xyz/anchor": "^0.30.1"
+    "change-case": "^5.4.4",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@solana/web3.js": "^1.98.0",
     "bn.js": "^5.2.1",
     "bs58": "^6.0.0",
-    "change-case": "^5.4.4",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './lib/explorer';
 export * from './lib/airdrop';
 export * from './lib/token';
 export * from './lib/logs';
+export * from './lib/idl';
 export * from './types';

--- a/src/lib/convertLegacyIdl.ts
+++ b/src/lib/convertLegacyIdl.ts
@@ -1,0 +1,477 @@
+/**
+ * This is a port of the anchor command `anchor idl convert` to TypeScript.
+ */
+import { Idl } from "@coral-xyz/anchor";
+import {
+  IdlAccount,
+  IdlConst,
+  IdlDefinedFields,
+  IdlEnumVariant,
+  IdlErrorCode,
+  IdlEvent,
+  IdlField,
+  IdlInstruction,
+  IdlInstructionAccountItem,
+  IdlInstructionAccounts,
+  IdlMetadata,
+  IdlType,
+  IdlTypeDef,
+  IdlTypeDefined,
+  IdlTypeDefTy,
+} from "@coral-xyz/anchor/dist/cjs/idl";
+import { sha256 } from "@noble/hashes/sha256";
+import { snakeCase, pascalCase } from "change-case";
+
+// Legacy types based on the Rust structs
+// Should be included in next minor release of anchor
+export interface LegacyIdl {
+  version: string;
+  name: string;
+  docs?: string[];
+  constants: LegacyIdlConst[];
+  instructions: LegacyIdlInstruction[];
+  accounts: LegacyIdlTypeDefinition[];
+  types: LegacyIdlTypeDefinition[];
+  events?: LegacyIdlEvent[];
+  errors?: LegacyIdlErrorCode[];
+  metadata?: any;
+}
+
+interface LegacyIdlConst {
+  name: string;
+  type: LegacyIdlType;
+  value: string;
+}
+
+interface LegacyIdlInstruction {
+  name: string;
+  docs?: string[];
+  accounts: LegacyIdlAccountItem[];
+  args: LegacyIdlField[];
+  returns?: LegacyIdlType;
+}
+
+interface LegacyIdlTypeDefinition {
+  name: string;
+  docs?: string[];
+  type: LegacyIdlTypeDefinitionTy;
+}
+
+type LegacyIdlTypeDefinitionTy =
+  | { kind: "struct"; fields: LegacyIdlField[] }
+  | { kind: "enum"; variants: LegacyIdlEnumVariant[] }
+  | { kind: "alias"; value: LegacyIdlType };
+
+interface LegacyIdlField {
+  name: string;
+  docs?: string[];
+  type: LegacyIdlType;
+}
+
+interface LegacyIdlEnumVariant {
+  name: string;
+  fields?: LegacyEnumFields;
+}
+
+type LegacyEnumFields = LegacyIdlField[] | LegacyIdlType[];
+
+interface LegacyIdlEvent {
+  name: string;
+  fields: LegacyIdlEventField[];
+}
+
+interface LegacyIdlEventField {
+  name: string;
+  type: LegacyIdlType;
+  index: boolean;
+}
+
+interface LegacyIdlErrorCode {
+  code: number;
+  name: string;
+  msg?: string;
+}
+
+type LegacyIdlAccountItem = LegacyIdlAccount | LegacyIdlAccounts;
+
+interface LegacyIdlAccount {
+  name: string;
+  isMut: boolean;
+  isSigner: boolean;
+  isOptional?: boolean;
+  docs?: string[];
+  pda?: LegacyIdlPda;
+  relations: string[];
+}
+
+interface LegacyIdlAccounts {
+  name: string;
+  accounts: LegacyIdlAccountItem[];
+}
+
+interface LegacyIdlPda {
+  seeds: LegacyIdlSeed[];
+  programId?: LegacyIdlSeed;
+}
+
+type LegacyIdlSeed =
+  | { kind: "const"; type: LegacyIdlType; value: any }
+  | { kind: "arg"; type: LegacyIdlType; path: string }
+  | { kind: "account"; type: LegacyIdlType; account?: string; path: string };
+
+type LegacyIdlType =
+  | "bool"
+  | "u8"
+  | "i8"
+  | "u16"
+  | "i16"
+  | "u32"
+  | "i32"
+  | "u64"
+  | "i64"
+  | "u128"
+  | "i128"
+  | "f32"
+  | "f64"
+  | "bytes"
+  | "string"
+  | "publicKey"
+  | { vec: LegacyIdlType }
+  | { option: LegacyIdlType }
+  | { defined: string }
+  | { array: [LegacyIdlType, number] }
+  | { generic: string }
+  | { definedWithTypeArgs: { name: string; args: LegacyIdlDefinedTypeArg[] } };
+
+type LegacyIdlDefinedTypeArg =
+  | { generic: string }
+  | { value: string }
+  | { type: LegacyIdlType };
+
+export function convertLegacyIdl(legacyIdl: LegacyIdl, programAddress?: string): Idl {
+  const address: string | undefined =
+    programAddress ?? legacyIdl.metadata?.address;
+  if (!address) {
+    throw new Error("Program id missing in `idl.metadata.address` field");
+  }
+  return {
+    accounts: (legacyIdl.accounts || []).map(convertAccount),
+    address: address,
+    constants: (legacyIdl.constants || []).map(convertConst),
+    errors: legacyIdl.errors?.map(convertErrorCode) || [],
+    events: legacyIdl.events?.map(convertEvent) || [],
+    instructions: legacyIdl.instructions.map(convertInstruction),
+    metadata: {
+      name: legacyIdl.name,
+      version: legacyIdl.version,
+    } as IdlMetadata,
+    types: [
+      ...(legacyIdl.types || []).map(convertTypeDef),
+      ...(legacyIdl.accounts || []).map(convertTypeDef),
+      ...(legacyIdl.events || []).map(convertEventToTypeDef),
+    ],
+  };
+}
+
+function traverseType(type: IdlType, refs: Set<string>) {
+  if (typeof type === "string") {
+    // skip
+  } else if ("vec" in type) {
+    traverseType(type.vec, refs);
+  } else if ("option" in type) {
+    traverseType(type.option, refs);
+  } else if ("defined" in type) {
+    refs.add(type.defined.name);
+  } else if ("array" in type) {
+    traverseType(type.array[0], refs);
+  } else if ("generic" in type) {
+    refs.add(type.generic);
+  } else if ("coption" in type) {
+    traverseType(type.coption, refs);
+  }
+}
+
+function traverseIdlFields(fields: IdlDefinedFields, refs: Set<string>) {
+  fields.forEach((field) =>
+    typeof field === "string"
+      ? traverseType(field, refs)
+      : typeof field === "object" && "type" in field
+      ? traverseType(field.type, refs)
+      : traverseType(field, refs),
+  );
+}
+
+function traverseTypeDef(type: IdlTypeDefTy, refs: Set<string>) {
+  switch (type.kind) {
+    case "struct":
+      traverseIdlFields(type.fields ?? [], refs);
+      return;
+    case "enum":
+      type.variants.forEach((variant) =>
+        traverseIdlFields(variant.fields ?? [], refs),
+      );
+      return;
+    case "type":
+      traverseType(type.alias, refs);
+      return;
+  }
+}
+
+function getTypeReferences(idl: Idl): Set<string> {
+  const refs = new Set<string>();
+  idl.constants?.forEach((constant) => traverseType(constant.type, refs));
+  idl.accounts?.forEach((account) => refs.add(account.name));
+  idl.instructions?.forEach((instruction) =>
+    instruction.args.forEach((arg) => traverseType(arg.type, refs)),
+  );
+  idl.events?.forEach((event) => refs.add(event.name));
+
+  // Build up recursive type references in breadth-first manner.
+  // Very inefficient since we traverse same types multiple times.
+  // But it works. Open to contributions that do proper graph traversal
+  let prevSize = refs.size;
+  let sizeDiff = 1;
+  while (sizeDiff > 0) {
+    for (const idlType of idl.types ?? []) {
+      if (refs.has(idlType.name)) {
+        traverseTypeDef(idlType.type, refs);
+      }
+    }
+    sizeDiff = refs.size - prevSize;
+    prevSize = refs.size;
+  }
+  return refs;
+}
+
+// Remove types that are not used in definition of instructions, accounts, events, or constants
+function removeUnusedTypes(idl: Idl): Idl {
+  const usedElsewhere = getTypeReferences(idl);
+  return {
+    ...idl,
+    types: (idl.types ?? []).filter((type) => usedElsewhere.has(type.name)),
+  };
+}
+
+function getDisc(prefix: string, name: string): number[] {
+  const hash = sha256(`${prefix}:${name}`);
+  return Array.from(hash.slice(0, 8));
+}
+
+function convertInstruction(instruction: LegacyIdlInstruction): IdlInstruction {
+  const name = snakeCase(instruction.name);
+  return {
+    accounts: instruction.accounts.map(convertInstructionAccount),
+    args: instruction.args.map(convertField),
+    discriminator: getDisc("global", name),
+    name,
+    returns: instruction.returns ? convertType(instruction.returns) : undefined,
+  };
+}
+
+function convertAccount(account: LegacyIdlTypeDefinition): IdlAccount {
+  return {
+    discriminator: getDisc("account", account.name),
+    name: account.name,
+  };
+}
+
+function convertTypeDef(typeDef: LegacyIdlTypeDefinition): IdlTypeDef {
+  return {
+    name: typeDef.name,
+    type: convertTypeDefTy(typeDef.type),
+  };
+}
+
+function convertTypeDefTy(type: LegacyIdlTypeDefinitionTy): IdlTypeDef["type"] {
+  switch (type.kind) {
+    case "struct":
+      return {
+        fields: type.fields.map(convertField),
+        kind: "struct",
+      };
+    case "enum":
+      return {
+        kind: "enum",
+        variants: type.variants.map(convertEnumVariant),
+      };
+    case "alias":
+      return {
+        alias: convertType(type.value),
+        kind: "type",
+      };
+  }
+}
+
+function convertField(field: LegacyIdlField): IdlField {
+  return {
+    name: snakeCase(field.name),
+    type: convertType(field.type),
+  };
+}
+
+function convertEnumVariant(variant: LegacyIdlEnumVariant): IdlEnumVariant {
+  return {
+    fields: variant.fields ? convertEnumFields(variant.fields) : undefined,
+    name: variant.name,
+  };
+}
+
+function convertEnumFields(fields: LegacyEnumFields): IdlDefinedFields {
+  if (
+    Array.isArray(fields) &&
+    fields.length > 0 &&
+    typeof fields[0] === "object" &&
+    "type" in fields[0]
+  ) {
+    return (fields as LegacyIdlField[]).map(convertField) as IdlField[];
+  } else {
+    return (fields as LegacyIdlType[]).map((type) =>
+      convertType(type),
+    ) as IdlType[];
+  }
+}
+
+function convertEvent(event: LegacyIdlEvent): IdlEvent {
+  return {
+    discriminator: getDisc("event", event.name),
+    name: event.name,
+  };
+}
+
+function convertErrorCode(error: LegacyIdlErrorCode): IdlErrorCode {
+  return {
+    code: error.code,
+    msg: error.msg,
+    name: error.name,
+  };
+}
+
+function convertConst(constant: LegacyIdlConst): IdlConst {
+  return {
+    name: constant.name,
+    type: convertType(constant.type),
+    value: constant.value,
+  };
+}
+
+function convertInstructionAccount(
+  account: LegacyIdlAccountItem,
+): IdlInstructionAccountItem {
+  if ("accounts" in account) {
+    return convertInstructionAccounts(account);
+  } else {
+    return {
+      docs: account.docs || [],
+      name: snakeCase(account.name),
+      optional: account.isOptional || false,
+      pda: account.pda ? convertPda(account.pda) : undefined,
+      relations: account.relations || [],
+      signer: account.isSigner || false,
+      writable: account.isMut || false,
+    };
+  }
+}
+
+function convertInstructionAccounts(
+  accounts: LegacyIdlAccounts,
+): IdlInstructionAccounts {
+  return {
+    accounts: accounts.accounts.map(convertInstructionAccount),
+    name: snakeCase(accounts.name),
+  };
+}
+
+function convertPda(pda: LegacyIdlPda): { seeds: any[]; programId?: any } {
+  return {
+    ...(pda.programId ? { programId: convertSeed(pda.programId) } : {}),
+    seeds: pda.seeds.map(convertSeed),
+  };
+}
+
+function convertSeed(seed: LegacyIdlSeed): any {
+  switch (seed.kind) {
+    case "const":
+      return { kind: "const", type: convertType(seed.type), value: seed.value };
+    case "arg":
+      return { kind: "arg", path: seed.path, type: convertType(seed.type) };
+    case "account":
+      return {
+        ...(seed.account ? { account: seed.account } : {}),
+        kind: "account",
+        path: seed.path,
+        type: convertType(seed.type),
+      };
+  }
+}
+
+function convertEventToTypeDef(event: LegacyIdlEvent): IdlTypeDef {
+  return {
+    name: event.name,
+    type: {
+      fields: event.fields.map((field) => ({
+        name: snakeCase(field.name),
+        type: convertType(field.type),
+      })),
+      kind: "struct",
+    },
+  };
+}
+
+function convertType(type: LegacyIdlType): IdlType {
+  if (typeof type === "string") {
+    return type === "publicKey" ? "pubkey" : type;
+  } else if ("vec" in type) {
+    return { vec: convertType(type.vec) };
+  } else if ("option" in type) {
+    return { option: convertType(type.option) };
+  } else if ("defined" in type) {
+    return { defined: { generics: [], name: type.defined } } as IdlTypeDefined;
+  } else if ("array" in type) {
+    return { array: [convertType(type.array[0]), type.array[1]] };
+  } else if ("generic" in type) {
+    return type;
+  } else if ("definedWithTypeArgs" in type) {
+    return {
+      defined: {
+        generics: type.definedWithTypeArgs.args.map(convertDefinedTypeArg),
+        name: type.definedWithTypeArgs.name,
+      },
+    } as IdlTypeDefined;
+  }
+  throw new Error(`Unsupported type: ${JSON.stringify(type)}`);
+}
+
+function convertDefinedTypeArg(arg: LegacyIdlDefinedTypeArg): any {
+  if ("generic" in arg) {
+    return { generic: arg.generic };
+  } else if ("value" in arg) {
+    return { value: arg.value };
+  } else if ("type" in arg) {
+    return { type: convertType(arg.type) };
+  }
+  throw new Error(`Unsupported defined type arg: ${JSON.stringify(arg)}`);
+}
+
+export function getIdlSpecType(idl: any): IdlSpec {
+  return idl.metadata?.spec ?? "legacy";
+}
+
+export type IdlSpec = "0.1.0" | "legacy";
+
+export function formatIdl(idl: any, programAddress?: string): Idl {
+  const spec = getIdlSpecType(idl);
+
+  switch (spec) {
+    case "0.1.0":
+      return idl as Idl;
+    case "legacy":
+      if (!programAddress) {
+        throw new Error("Program address is required for legacy IDL");
+      }
+      return removeUnusedTypes(
+        convertLegacyIdl(idl as LegacyIdl, programAddress),
+      );
+    default:
+      throw new Error(`IDL spec not supported: ${spec}`);
+  }
+}

--- a/src/lib/idl.ts
+++ b/src/lib/idl.ts
@@ -15,7 +15,7 @@ import {
 } from "@coral-xyz/anchor";
 import BN from "bn.js";
 import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
-import { convertLegacyIdl, formatIdl, LegacyIdl } from "./convertLegacyIdl";
+import { formatIdl } from "./convertLegacyIdl";
 
 /**
  * Loads an Anchor IDL from a local file path

--- a/src/lib/idl.ts
+++ b/src/lib/idl.ts
@@ -1,0 +1,361 @@
+import {
+  Connection,
+  PublicKey,
+  MessageCompiledInstruction,
+  Keypair,
+  Message,
+} from "@solana/web3.js";
+import {
+  Program,
+  Idl,
+  AnchorProvider,
+  EventParser,
+  BorshAccountsCoder,
+  BorshInstructionCoder,
+} from "@coral-xyz/anchor";
+import BN from "bn.js";
+import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
+import { convertLegacyIdl, formatIdl, LegacyIdl } from "./convertLegacyIdl";
+
+/**
+ * Loads an Anchor IDL from a local file path
+ *
+ * @param idlPath - Path to the IDL JSON file
+ * @returns The parsed IDL
+ *
+ * @example
+ * ```typescript
+ * const idl = await getIDlbyPath("./idl/program.json");
+ * ```
+ */
+export async function getIDlbyPath<Idl>(idlPath: string): Promise<Idl> {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+
+  // Load and parse IDL file
+  const idlFile = fs.readFileSync(path.resolve(idlPath), "utf8");
+  const idl = JSON.parse(idlFile) as Idl;
+  return idl;
+}
+
+/**
+ * Fetches an Anchor IDL from a program on-chain
+ *
+ * @param programId - Public key of the program
+ * @param connection - Solana connection object
+ * @returns The fetched IDL
+ * @throws If IDL cannot be found for the program
+ *
+ * @example
+ * ```typescript
+ * const idl = await getIDlByProgramId(
+ *   new PublicKey("Foo1111111111111111111111111111111111111"),
+ *   connection
+ * );
+ * ```
+ */
+export async function getIDlByProgramId<Idl>(
+  programId: PublicKey,
+  connection: Connection,
+): Promise<Idl> {
+  let wallet = new NodeWallet(new Keypair());
+  const provider = new AnchorProvider(connection, wallet, {
+    commitment: "confirmed",
+  });
+
+  var idl = await Program.fetchIdl(programId, provider);
+  if (!idl)
+    throw new Error(`IDL not found for program ${programId.toString()}`);
+
+  return idl as Idl;
+}
+
+/**
+ * Fetches and parses an account's data using an Anchor IDL
+ *
+ * @param idl - The Anchor IDL (use getIDlByProgramId or getIDlbyPath to obtain)
+ * @param accountName - The name of the account as defined in the IDL
+ * @param accountAddress - The public key of the account to fetch
+ * @param connection - Optional connection object (uses default provider if not specified)
+ * @param programId - Optional program ID needed for legacy IDLs
+ * @returns The decoded account data
+ *
+ * @example
+ * ```typescript
+ * const idl = await getIDlByProgramId(programId, connection);
+ * const data = await getIdlParsedAccountData(idl, "counter", accountAddress);
+ * ```
+ */
+export async function getIdlParsedAccountData<T = any>(
+  idl: Idl,
+  accountName: string,
+  accountAddress: PublicKey,
+  connection: Connection,
+  programId?: PublicKey,
+): Promise<T> {
+  // Get or create provider
+  let wallet = new NodeWallet(new Keypair());
+
+  const provider = new AnchorProvider(connection, wallet, {
+    commitment: "confirmed",
+  });
+
+  // Create program
+  const program = new Program(formatIdl(idl, programId?.toString()), provider);
+
+  const accountInfo = await provider.connection.getAccountInfo(accountAddress);
+
+  if (!accountInfo) {
+    throw new Error(`Account ${accountAddress.toString()} not found`);
+  }
+
+  return program.coder.accounts.decode(accountName, accountInfo.data) as T;
+}
+
+/**
+ * Parses Anchor events from a transaction
+ *
+ * @param idl - The Anchor IDL (use getIDlByProgramId or getIDlbyPath to obtain)
+ * @param signature - Transaction signature to parse events from
+ * @param connection - Connection object (uses default provider if not specified)
+ * @param programId - Optional program ID needed for legacy IDLs
+ * @returns Array of parsed events with their name and data
+ *
+ * @example
+ * ```typescript
+ * const idl = await getIDlbyPath("./idl/program.json");
+ * const events = await parseAnchorTransactionEvents(idl, signature);
+ * ```
+ */
+export async function parseAnchorTransactionEvents(
+  idl: Idl,
+  signature: string,
+  connection: Connection,
+  programId?: PublicKey,
+): Promise<
+  Array<{
+    name: string;
+    data: any;
+  }>
+> {
+  let wallet = new NodeWallet(new Keypair());
+
+  const provider = new AnchorProvider(connection, wallet, {
+    commitment: "confirmed",
+  });
+
+  const program = new Program(formatIdl(idl, programId?.toString()), provider);
+  const parser = new EventParser(program.programId, program.coder);
+
+  const transaction = await provider.connection.getTransaction(signature, {
+    commitment: "confirmed",
+    maxSupportedTransactionVersion: 0,
+  });
+
+  if (!transaction?.meta?.logMessages) {
+    return [];
+  }
+
+  const events: Array<{ name: string; data: any }> = [];
+  for (const event of parser.parseLogs(transaction.meta.logMessages)) {
+    events.push({
+      name: event.name,
+      data: event.data,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Account involved in an instruction
+ */
+type InvolvedAccount = {
+  name: string;
+  pubkey: string;
+  isSigner: boolean;
+  isWritable: boolean;
+  data?: Record<string, any>; // Decoded account data if it's a program account
+};
+
+/**
+ * Decoded Anchor instruction with all involved accounts
+ */
+export type DecodedAnchorInstruction = {
+  name: string;
+  type: string;
+  data: Record<string, any>;
+  accounts: InvolvedAccount[];
+  toString: () => string;
+};
+
+/**
+ * Decoded Anchor transaction containing all instructions and their accounts
+ */
+export type DecodedTransaction = {
+  instructions: DecodedAnchorInstruction[];
+  toString: () => string;
+};
+
+/**
+ * Decodes all Anchor instructions and their involved accounts in a transaction
+ *
+ * @param idl - The Anchor IDL (use getIDlByProgramId or getIDlbyPath to obtain)
+ * @param signature - Transaction signature to decode
+ * @param connection - Optional connection object (uses default provider if not specified)
+ * @param programId - Optional program ID needed for legacy IDLs
+ * @returns Decoded transaction with instructions and accounts
+ *
+ * @example
+ * ```typescript
+ * const idl = await getIDlByProgramId(programId, connection);
+ * const decoded = await decodeAnchorTransaction(idl, signature);
+ * ```
+ */
+export async function decodeAnchorTransaction(
+  idl: Idl,
+  signature: string,
+  connection: Connection,
+  programId?: PublicKey,
+): Promise<DecodedTransaction> {
+  let wallet = new NodeWallet(new Keypair());
+  const provider = new AnchorProvider(connection, wallet, {
+    commitment: "confirmed",
+  });
+  const program = new Program(formatIdl(idl, programId?.toString()), provider);
+  const accountsCoder = new BorshAccountsCoder(program.idl);
+  const instructionCoder = new BorshInstructionCoder(program.idl);
+
+  const transaction = await provider.connection.getTransaction(signature, {
+    commitment: "confirmed",
+    maxSupportedTransactionVersion: 0,
+  });
+
+  if (!transaction) {
+    throw new Error(`Transaction ${signature} not found`);
+  }
+
+  const decodedInstructions: DecodedAnchorInstruction[] = [];
+
+  const message = transaction.transaction.message;
+  const instructions =
+    "addressTableLookups" in message
+      ? message.compiledInstructions
+      : (message as Message).instructions;
+  const accountKeys = message.getAccountKeys();
+
+  for (const ix of instructions) {
+    const programId = accountKeys.get(
+      "programIdIndex" in ix
+        ? (ix as MessageCompiledInstruction).programIdIndex
+        : (ix as any).programId,
+    );
+
+    if (!programId) continue;
+    if (programId.equals(program.programId)) {
+      try {
+        const decoded = instructionCoder.decode(Buffer.from(ix.data));
+        if (decoded) {
+          const ixType = idl.instructions.find((i) => i.name === decoded.name);
+          const accountIndices =
+            "accounts" in ix ? ix.accounts : ix.accountKeyIndexes;
+
+          // Get all accounts involved in this instruction
+          const accounts: InvolvedAccount[] = await Promise.all(
+            accountIndices.map(async (index, i) => {
+              const pubkey = accountKeys.get(index);
+              if (!pubkey) return null;
+              const accountMeta = ixType?.accounts[i];
+              const accountInfo =
+                await provider.connection.getAccountInfo(pubkey);
+
+              let accountData;
+              if (accountInfo?.owner.equals(program.programId)) {
+                try {
+                  const accountType = idl.accounts?.find((acc) =>
+                    accountInfo.data
+                      .slice(0, 8)
+                      .equals(accountsCoder.accountDiscriminator(acc.name.toLowerCase())),
+                  );
+                  if (accountType) {
+                    accountData = accountsCoder.decode(
+                      accountType.name.toLowerCase(),
+                      accountInfo.data,
+                    );
+                  }
+                } catch (e) {
+                  console.log(`Failed to decode account data: ${e}`);
+                }
+              }
+
+              return {
+                name: accountMeta?.name || `account_${i}`,
+                pubkey: pubkey.toString(),
+                isSigner:
+                  message.staticAccountKeys.findIndex((k) => k.equals(pubkey)) <
+                    message.header.numRequiredSignatures || false,
+                isWritable: message.isAccountWritable(index),
+                ...(accountData && { data: accountData }),
+              };
+            }),
+          );
+
+          decodedInstructions.push({
+            name: decoded.name,
+            type: ixType ? JSON.stringify(ixType.args) : "unknown",
+            data: decoded.data,
+            accounts,
+            toString: function () {
+              let output = `\nInstruction: ${this.name}\n`;
+              output += `├─ Arguments: ${JSON.stringify(
+                formatData(this.data),
+              )}\n`;
+              output += `└─ Accounts:\n`;
+              this.accounts.forEach((acc) => {
+                output += `   ├─ ${acc.name}:\n`;
+                output += `   │  ├─ Address: ${acc.pubkey}\n`;
+                output += `   │  ├─ Signer: ${acc.isSigner}\n`;
+                output += `   │  ├─ Writable: ${acc.isWritable}\n`;
+                if (acc.data) {
+                  output += `   │  └─ Data: ${JSON.stringify(
+                    formatData(acc.data),
+                  )}\n`;
+                }
+              });
+              return output;
+            },
+          });
+        }
+      } catch (e) {
+        console.log(`Failed to decode instruction: ${e}`);
+      }
+    }
+  }
+
+  return {
+    instructions: decodedInstructions,
+    toString: function (this: DecodedTransaction) {
+      let output = "\n=== Decoded Transaction ===\n";
+      this.instructions.forEach((ix, index) => {
+        output += `\nInstruction ${index + 1}:${ix.toString()}`;
+      });
+      return output;
+    },
+  };
+}
+
+// Helper function to format data
+function formatData(data: any): any {
+  if (data instanceof BN) {
+    return `<BN: ${data.toString()}>`;
+  }
+  if (Array.isArray(data)) {
+    return data.map(formatData);
+  }
+  if (typeof data === "object" && data !== null) {
+    return Object.fromEntries(
+      Object.entries(data).map(([k, v]) => [k, formatData(v)]),
+    );
+  }
+  return data;
+}

--- a/src/lib/idl.ts
+++ b/src/lib/idl.ts
@@ -25,10 +25,10 @@ import { formatIdl } from "./convertLegacyIdl";
  *
  * @example
  * ```typescript
- * const idl = await getIDlbyPath("./idl/program.json");
+ * const idl = await getIdlByPath("./idl/program.json");
  * ```
  */
-export async function getIDlbyPath<Idl>(idlPath: string): Promise<Idl> {
+export async function getIdlByPath<Idl>(idlPath: string): Promise<Idl> {
   const fs = await import("node:fs");
   const path = await import("node:path");
 
@@ -48,13 +48,13 @@ export async function getIDlbyPath<Idl>(idlPath: string): Promise<Idl> {
  *
  * @example
  * ```typescript
- * const idl = await getIDlByProgramId(
+ * const idl = await getIdlByProgramId(
  *   new PublicKey("Foo1111111111111111111111111111111111111"),
  *   connection
  * );
  * ```
  */
-export async function getIDlByProgramId<Idl>(
+export async function getIdlByProgramId<Idl>(
   programId: PublicKey,
   connection: Connection,
 ): Promise<Idl> {
@@ -73,7 +73,7 @@ export async function getIDlByProgramId<Idl>(
 /**
  * Fetches and parses an account's data using an Anchor IDL
  *
- * @param idl - The Anchor IDL (use getIDlByProgramId or getIDlbyPath to obtain)
+ * @param idl - The Anchor IDL (use getIdlByProgramId or getIdlByPath to obtain)
  * @param accountName - The name of the account as defined in the IDL
  * @param accountAddress - The public key of the account to fetch
  * @param connection - Optional connection object (uses default provider if not specified)
@@ -82,7 +82,7 @@ export async function getIDlByProgramId<Idl>(
  *
  * @example
  * ```typescript
- * const idl = await getIDlByProgramId(programId, connection);
+ * const idl = await getIdlByProgramId(programId, connection);
  * const data = await getIdlParsedAccountData(idl, "counter", accountAddress);
  * ```
  */
@@ -115,7 +115,7 @@ export async function getIdlParsedAccountData<T = any>(
 /**
  * Parses Anchor events from a transaction
  *
- * @param idl - The Anchor IDL (use getIDlByProgramId or getIDlbyPath to obtain)
+ * @param idl - The Anchor IDL (use getIdlByProgramId or getIdlByPath to obtain)
  * @param signature - Transaction signature to parse events from
  * @param connection - Connection object (uses default provider if not specified)
  * @param programId - Optional program ID needed for legacy IDLs
@@ -123,7 +123,7 @@ export async function getIdlParsedAccountData<T = any>(
  *
  * @example
  * ```typescript
- * const idl = await getIDlbyPath("./idl/program.json");
+ * const idl = await getIdlByPath("./idl/program.json");
  * const events = await parseAnchorTransactionEvents(idl, signature);
  * ```
  */
@@ -200,7 +200,7 @@ export type DecodedTransaction = {
 /**
  * Decodes all Anchor instructions and their involved accounts in a transaction
  *
- * @param idl - The Anchor IDL (use getIDlByProgramId or getIDlbyPath to obtain)
+ * @param idl - The Anchor IDL (use getIdlByProgramId or getIdlByPath to obtain)
  * @param signature - Transaction signature to decode
  * @param connection - Optional connection object (uses default provider if not specified)
  * @param programId - Optional program ID needed for legacy IDLs
@@ -208,7 +208,7 @@ export type DecodedTransaction = {
  *
  * @example
  * ```typescript
- * const idl = await getIDlByProgramId(programId, connection);
+ * const idl = await getIdlByProgramId(programId, connection);
  * const decoded = await decodeAnchorTransaction(idl, signature);
  * ```
  */
@@ -275,7 +275,11 @@ export async function decodeAnchorTransaction(
                   const accountType = idl.accounts?.find((acc) =>
                     accountInfo.data
                       .slice(0, 8)
-                      .equals(accountsCoder.accountDiscriminator(acc.name.toLowerCase())),
+                      .equals(
+                        accountsCoder.accountDiscriminator(
+                          acc.name.toLowerCase(),
+                        ),
+                      ),
                   );
                   if (accountType) {
                     accountData = accountsCoder.decode(

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -421,8 +421,9 @@ export async function sendTransaction(
     });
   }
 
-  const hasComputeInstructions = transaction.instructions.some((ix: TransactionInstruction) =>
-    ix.programId.equals(ComputeBudgetProgram.programId),
+  const hasComputeInstructions = transaction.instructions.some(
+    (ix: TransactionInstruction) =>
+      ix.programId.equals(ComputeBudgetProgram.programId),
   );
 
   if (hasComputeInstructions) {
@@ -765,6 +766,10 @@ export async function CreateLookupTable(
       commitment: "confirmed",
     })
   ).value;
+
+  if (!lookupTableAccount) {
+    throw new Error("Failed to get lookup table account");
+  }
 
   return [lookupTableAddress, lookupTableAccount];
 }

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -43,13 +43,20 @@ export const getSimulationComputeUnits = async (
   lookupTables: Array<AddressLookupTableAccount> | [],
   commitment: Commitment = "confirmed",
 ): Promise<number | null> => {
-  const testInstructions = [
-    // Set an arbitrarily high number in simulation
-    // so we can be sure the transaction will succeed
-    // and get the real compute units used
-    ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
-    ...instructions,
-  ];
+  const hasComputeInstructions = instructions.some(
+    (ix: TransactionInstruction) =>
+      ix.programId.equals(ComputeBudgetProgram.programId),
+  );
+
+  const testInstructions = hasComputeInstructions
+    ? instructions
+    : [
+        // Set an arbitrarily high number in simulation
+        // so we can be sure the transaction will succeed
+        // and get the real compute units used
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+        ...instructions,
+      ];
 
   const testTransaction = new VersionedTransaction(
     new TransactionMessage({

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -353,7 +353,7 @@ export async function sendVersionedTransaction(
 }
 
 /**
- * Adds compute unit price and limit instructions to the transaction
+ * Adds compute unit price and limit instructions and returns the updated instructions
  *
  * @param connection - The Solana connection object
  * @param instructions - Array of instructions to which compute unit instructions will be added

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -229,7 +229,7 @@ async function sendTransactionWithRetry(
       });
 
       if (isFirstSend) {
-        onStatusUpdate?.({ status: "sent", signature });
+        onStatusUpdate?.({ status: "sent", signature: signature ?? "" });
       }
 
       // Poll for confirmation
@@ -245,7 +245,7 @@ async function sendTransactionWithRetry(
             status.confirmationStatus === "finalized"
           ) {
             onStatusUpdate?.({ status: "confirmed", result: status });
-            return signature;
+            return signature ?? "";
           }
         }
         pollTimeout -= timeBetweenPolls;
@@ -421,7 +421,7 @@ export async function sendTransaction(
     });
   }
 
-  const hasComputeInstructions = transaction.instructions.some((ix) =>
+  const hasComputeInstructions = transaction.instructions.some((ix: TransactionInstruction) =>
     ix.programId.equals(ComputeBudgetProgram.programId),
   );
 
@@ -494,7 +494,7 @@ export async function sendVersionedTransaction(
   instructions: Array<TransactionInstruction>,
   signers: Keypair[],
   priorityFee: number = 10000,
-  lookupTables?: Array<AddressLookupTableAccount> | [],
+  lookupTables?: Array<AddressLookupTableAccount>,
   options: SendTransactionOptions & {
     computeUnitBuffer?: ComputeUnitBuffer;
   } = {},
@@ -514,7 +514,7 @@ export async function sendVersionedTransaction(
     instructions = await addComputeInstructions(
       connection,
       instructions,
-      lookupTables,
+      lookupTables ?? [],
       signers[0].publicKey,
       priorityFee,
       computeUnitBuffer,
@@ -555,7 +555,7 @@ export async function sendVersionedTransaction(
 async function addComputeInstructions(
   connection: Connection,
   instructions: Array<TransactionInstruction>,
-  lookupTables: Array<AddressLookupTableAccount> | [],
+  lookupTables: Array<AddressLookupTableAccount>,
   payer: PublicKey,
   priorityFee: number = 10000,
   computeUnitBuffer: ComputeUnitBuffer = {},
@@ -669,7 +669,7 @@ async function sendVersionedTransactionWithRetry(
       });
 
       if (isFirstSend) {
-        onStatusUpdate?.({ status: "sent", signature });
+        onStatusUpdate?.({ status: "sent", signature: signature ?? "" });
       }
 
       // Poll for confirmation
@@ -685,7 +685,7 @@ async function sendVersionedTransactionWithRetry(
             status.confirmationStatus === "finalized"
           ) {
             onStatusUpdate?.({ status: "confirmed", result: status });
-            return signature;
+            return signature ?? "";
           }
         }
         pollTimeout -= timeBetweenPolls;

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -725,7 +725,7 @@ async function sendVersionedTransactionWithRetry(
  * @param additionalAddresses - Array of additional addresses to include in the lookup table
  * @returns A tuple containing the lookup table address and the lookup table account
  */
-export async function CreateLookupTable(
+export async function createLookupTable(
   connection: Connection,
   sender: Keypair,
   additionalAddresses: PublicKey[],

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -33,6 +33,44 @@ export const confirmTransaction = async (
   return signature;
 };
 
+/**
+ * Check if a given instruction is a SetComputeUnitLimit instruction
+ * See https://github.com/solana-program/compute-budget/blob/main/clients/js/src/generated/programs/computeBudget.ts#L29
+ */
+function isSetComputeLimitInstruction(ix: TransactionInstruction): boolean {
+  return (
+    ix.programId.equals(ComputeBudgetProgram.programId) && ix.data[0] === 2 // opcode for setComputeUnitLimit is 2
+  );
+}
+
+/**
+ * Check if a given instruction is a SetComputeUnitLimit instruction
+ * See https://github.com/solana-program/compute-budget/blob/main/clients/js/src/generated/programs/computeBudget.ts#L30
+ */
+function isSetComputeUnitPriceInstruction(ix: TransactionInstruction): boolean {
+  return (
+    ix.programId.equals(ComputeBudgetProgram.programId) && ix.data[0] === 3 // opcode for setComputeUnitPrice is 3
+  );
+}
+
+/**
+ * Check if a given transaction contains a SetComputeUnitLimit instruction
+ */
+export function hasSetComputeLimitInstruction(
+  instructions: Array<TransactionInstruction>,
+): boolean {
+  return instructions.filter(isSetComputeLimitInstruction).length === 1;
+}
+
+/**
+ * Check if a given transaction contains a SetComputeUnitLimit instruction
+ */
+export function hasSetComputeUnitPriceInstruction(
+  instructions: Array<TransactionInstruction>,
+): boolean {
+  return instructions.filter(isSetComputeUnitPriceInstruction).length === 1;
+}
+
 // Was getSimulationUnits
 // Credit https://twitter.com/stegabob, originally from
 // https://x.com/stegaBOB/status/1766662289392889920
@@ -43,24 +81,25 @@ export const getSimulationComputeUnits = async (
   lookupTables: Array<AddressLookupTableAccount> | [],
   commitment: Commitment = "confirmed",
 ): Promise<number | null> => {
-  const hasComputeInstructions = instructions.some(
-    (ix: TransactionInstruction) =>
-      ix.programId.equals(ComputeBudgetProgram.programId),
-  );
+  const simulationInstructions = [...instructions];
 
-  const testInstructions = hasComputeInstructions
-    ? instructions
-    : [
-        // Set an arbitrarily high number in simulation
-        // so we can be sure the transaction will succeed
-        // and get the real compute units used
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
-        ...instructions,
-      ];
+  // Replace or add compute limit instruction
+  const computeLimitIndex = simulationInstructions.findIndex(
+    isSetComputeLimitInstruction,
+  );
+  const simulationLimitIx = ComputeBudgetProgram.setComputeUnitLimit({
+    units: 1_400_000,
+  });
+
+  if (computeLimitIndex >= 0) {
+    simulationInstructions[computeLimitIndex] = simulationLimitIx;
+  } else {
+    simulationInstructions.unshift(simulationLimitIx);
+  }
 
   const testTransaction = new VersionedTransaction(
     new TransactionMessage({
-      instructions: testInstructions,
+      instructions: simulationInstructions,
       payerKey: payer,
       // RecentBlockhash can by any public key during simulation
       // since 'replaceRecentBlockhash' is set to 'true' below
@@ -144,234 +183,12 @@ export const DEFAULT_SEND_OPTIONS: Required<
 };
 
 /**
- * Sends a transaction with automatic retries and status updates
- *
- * @param connection - The Solana connection object
- * @param transaction - The transaction to send
- * @param signers - Array of signers needed for the transaction
- * @param options - Optional configuration for the retry mechanism
- *
- * @returns Promise that resolves to the transaction signature
- *
- * @remarks
- * This function implements a robust retry mechanism that:
- * 1. Signs the transaction (if signers are provided)
- * 2. Sends the transaction only once
- * 3. Monitors the transaction status until confirmation
- * 4. Retries on failure with a fixed delay
- * 5. Provides detailed status updates through the callback
- *
- * The function uses default values that can be partially overridden through the options parameter.
- * Default values are defined in DEFAULT_SEND_OPTIONS.
- *
- * Status updates include:
- * - "created": Initial transaction state
- * - "signed": Transaction has been signed
- * - "sent": Transaction has been sent (includes signature)
- * - "confirmed": Transaction is confirmed or finalized
- *
- * @throws Error if the transaction fails after all retry attempts
- *
- * @example
- * ```typescript
- * const signature = await sendTransactionWithRetry(
- *   connection,
- *   transaction,
- *   signers,
- *   {
- *     onStatusUpdate: (status) => console.log(status),
- *     commitment: "confirmed"
- *   }
- * );
- * ```
- */
-async function sendTransactionWithRetry(
-  connection: Connection,
-  transaction: Transaction,
-  signers: Keypair[],
-  {
-    maxRetries = DEFAULT_SEND_OPTIONS.maxRetries,
-    initialDelayMs = DEFAULT_SEND_OPTIONS.initialDelayMs,
-    commitment = DEFAULT_SEND_OPTIONS.commitment,
-    skipPreflight = DEFAULT_SEND_OPTIONS.skipPreflight,
-    onStatusUpdate = (status) => console.log("Transaction status:", status),
-  }: SendTransactionOptions = {},
-): Promise<string> {
-  onStatusUpdate?.({ status: "created" });
-
-  // Sign the transaction
-  if (signers.length > 0) {
-    transaction.sign(...signers);
-  }
-
-  if (transaction.recentBlockhash === undefined) {
-    console.log("No blockhash provided. Setting recent blockhash");
-    const { blockhash } = await connection.getLatestBlockhash(commitment);
-    transaction.recentBlockhash = blockhash;
-  }
-  if (transaction.feePayer === undefined) {
-    if (signers.length === 0) {
-      throw new Error("No signers or fee payer provided");
-    }
-    transaction.feePayer = signers[0].publicKey;
-  }
-
-  onStatusUpdate?.({ status: "signed" });
-
-  let signature: string | null = null;
-  let status: SignatureStatus | null = null;
-  let retries = 0;
-  // Setting a minimum to decrease spam and for the confirmation to work
-  let delayBetweenRetries = Math.max(initialDelayMs, 500);
-
-  while (retries < maxRetries) {
-    try {
-      const isFirstSend = signature === null;
-
-      // Send transaction if not sent yet
-      signature = await connection.sendRawTransaction(transaction.serialize(), {
-        skipPreflight,
-        preflightCommitment: commitment,
-        maxRetries: 0,
-      });
-
-      if (isFirstSend) {
-        onStatusUpdate?.({ status: "sent", signature: signature ?? "" });
-      }
-
-      // Poll for confirmation
-      let pollTimeout = delayBetweenRetries;
-      const timeBetweenPolls = 500;
-      while (pollTimeout > 0) {
-        await new Promise((resolve) => setTimeout(resolve, timeBetweenPolls));
-        const response = await connection.getSignatureStatus(signature);
-        if (response?.value) {
-          status = response.value;
-          if (
-            status.confirmationStatus === "confirmed" ||
-            status.confirmationStatus === "finalized"
-          ) {
-            onStatusUpdate?.({ status: "confirmed", result: status });
-            return signature ?? "";
-          }
-        }
-        pollTimeout -= timeBetweenPolls;
-      }
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        console.log(`Attempt ${retries + 1} failed:`, error.message);
-      } else {
-        console.log(`Attempt ${retries + 1} failed:`, error);
-      }
-    }
-
-    retries++;
-
-    if (retries < maxRetries) {
-      onStatusUpdate?.({ status: "retry", signature: signature ?? null });
-      delayBetweenRetries += RETRY_INTERVAL_INCREASE;
-    }
-  }
-
-  throw new Error(`Transaction failed after ${maxRetries} attempts`);
-}
-
-/**
- * Prepares a transaction by adding compute budget instructions
- *
- * @param connection - The Solana connection object
- * @param tx - The transaction to prepare
- * @param payer - The public key of the transaction payer
- * @param priorityFee - Priority fee in microLamports (default: 10000 which is the minimum required for helius to see a transaction as priority)
- * @param computeUnitBuffer - Optional buffer to add to simulated compute units
- *
- * @remarks
- * This function:
- * 1. Adds a compute unit price instruction with the specified priority fee
- * 2. Simulates the transaction to determine required compute units
- * 3. Applies any specified compute unit buffers
- * 4. Adds a compute unit limit instruction based on the simulation
- *
- * The compute unit buffer can be specified as:
- * - A multiplier (e.g., 1.1 adds 10% to simulated units)
- * - A fixed value (e.g., 1000 adds 1000 compute units)
- * - Both (multiplier is applied first, then fixed value is added)
- *
- * Priority Fees:
- * To find an appropriate priority fee, refer to your RPC provider's documentation:
- * - Helius: https://docs.helius.dev/solana-apis/priority-fee-api
- * - Triton: https://docs.triton.one/chains/solana/improved-priority-fees-api
- * - Quicknode: https://www.quicknode.com/docs/solana/qn_estimatePriorityFees
- *
- * @throws If the transaction simulation fails
- *
- * @example
- * ```typescript
- * // Add 10% buffer plus 1000 fixed compute units
- * await prepareTransactionWithCompute(
- *   connection,
- *   transaction,
- *   payer.publicKey,
- *   1000,
- *   { multiplier: 1.1, fixed: 1000 }
- * );
- * ```
- */
-export async function prepareTransactionWithCompute(
-  connection: Connection,
-  tx: Transaction,
-  payer: PublicKey,
-  priorityFee: number = 10000,
-  computeUnitBuffer: ComputeUnitBuffer = {},
-  commitment: Commitment = "confirmed",
-): Promise<void> {
-  tx.add(
-    ComputeBudgetProgram.setComputeUnitPrice({
-      microLamports: priorityFee,
-    }),
-  );
-
-  const simulatedCompute = await getSimulationComputeUnits(
-    connection,
-    tx.instructions,
-    payer,
-    [],
-    commitment,
-  );
-
-  if (simulatedCompute === null) {
-    throw new Error("Failed to simulate compute units");
-  }
-
-  console.log("Simulated compute units", simulatedCompute);
-
-  // Apply buffer to compute units
-  let finalComputeUnits = simulatedCompute;
-  if (computeUnitBuffer.multiplier) {
-    finalComputeUnits = Math.floor(
-      finalComputeUnits * computeUnitBuffer.multiplier,
-    );
-  }
-  if (computeUnitBuffer.fixed) {
-    finalComputeUnits += computeUnitBuffer.fixed;
-  }
-
-  console.log("Final compute units (with buffer)", finalComputeUnits);
-
-  tx.add(
-    ComputeBudgetProgram.setComputeUnitLimit({
-      units: finalComputeUnits,
-    }),
-  );
-}
-
-/**
  * Sends a transaction with compute unit optimization and automatic retries
  *
  * @param connection - The Solana connection object
  * @param transaction - The transaction to send
  * @param signers - Array of signers needed for the transaction
- * @param priorityFee - Priority fee in microLamports (default: 10000 which is the minimum required for helius to see a transaction as priority)
+ * @param priorityFee - Priority fee in microLamports (default: 10000)
  * @param options - Optional configuration for retry mechanism and compute units
  * @returns Promise that resolves to the transaction signature
  *
@@ -399,7 +216,7 @@ export async function sendTransaction(
   } = {},
 ): Promise<string> {
   const {
-    computeUnitBuffer: userComputeBuffer, // Rename to make clear it's user provided
+    computeUnitBuffer: userComputeBuffer,
     commitment = "confirmed",
     ...sendOptions
   } = options;
@@ -422,36 +239,24 @@ export async function sendTransaction(
   // Skip compute preparation if transaction is already signed or has compute instructions
   if (transaction.signatures.length > 0) {
     console.log("Transaction already signed, skipping compute preparation");
-    return sendTransactionWithRetry(connection, transaction, signers, {
+    return sendRawTransactionWithRetry(connection, transaction.serialize(), {
       commitment,
       ...sendOptions,
     });
   }
 
-  const hasComputeInstructions = transaction.instructions.some(
-    (ix: TransactionInstruction) =>
-      ix.programId.equals(ComputeBudgetProgram.programId),
-  );
-
-  if (hasComputeInstructions) {
-    console.log(
-      "Transaction already has compute instructions, skipping compute preparation",
-    );
-    return sendTransactionWithRetry(connection, transaction, signers, {
-      commitment,
-      ...sendOptions,
-    });
-  }
-  await prepareTransactionWithCompute(
+  transaction.instructions = await addComputeInstructions(
     connection,
-    transaction,
+    transaction.instructions,
+    [],
     transaction.feePayer,
     priorityFee,
     computeUnitBuffer,
     commitment,
   );
 
-  return sendTransactionWithRetry(connection, transaction, signers, {
+  transaction.sign(...signers);
+  return sendRawTransactionWithRetry(connection, transaction.serialize(), {
     commitment,
     ...sendOptions,
   });
@@ -463,7 +268,7 @@ export async function sendTransaction(
  * @param connection - The Solana connection object
  * @param instructions - Array of instructions to include in the transaction
  * @param signers - Array of signers needed for the transaction
- * @param priorityFee - Priority fee in microLamports (default: 10000 which is the minimum required for helius to see a transaction as priority)
+ * @param priorityFee - Priority fee in microLamports (default: 10000)
  * @param lookupTables - Optional array of address lookup tables for account compression
  * @param options - Optional configuration for retry mechanism and compute units
  * @returns Promise that resolves to the transaction signature
@@ -513,11 +318,10 @@ export async function sendVersionedTransaction(
     ...sendOptions
   } = options;
 
-  const hasComputeInstructions = instructions.some((ix) =>
-    ix.programId.equals(ComputeBudgetProgram.programId),
-  );
+  const hasComputeLimitInstructions =
+    hasSetComputeLimitInstruction(instructions);
 
-  if (!hasComputeInstructions) {
+  if (!hasComputeLimitInstructions) {
     const computeUnitBuffer = userComputeBuffer ?? { multiplier: 1.1 };
     instructions = await addComputeInstructions(
       connection,
@@ -541,9 +345,9 @@ export async function sendVersionedTransaction(
 
   transaction.sign(signers);
 
-  return await sendVersionedTransactionWithRetry(
+  return await sendRawTransactionWithRetry(
     connection,
-    transaction,
+    transaction.serialize(),
     sendOptions,
   );
 }
@@ -555,12 +359,12 @@ export async function sendVersionedTransaction(
  * @param instructions - Array of instructions to which compute unit instructions will be added
  * @param lookupTables - Optional array of address lookup tables for account compression
  * @param payer - The public key of the transaction payer
- * @param priorityFee - Priority fee in microLamports (default: 10000 which is the minimum required for helius to see a transaction as priority)
+ * @param priorityFee - Priority fee in microLamports (default: 10000)
  * @param computeUnitBuffer - Optional buffer to add to simulated compute units
  * @param commitment - Desired commitment level for the transaction
  * @returns Array of instructions with compute unit instructions added
  */
-async function addComputeInstructions(
+export async function addComputeInstructions(
   connection: Connection,
   instructions: Array<TransactionInstruction>,
   lookupTables: Array<AddressLookupTableAccount>,
@@ -569,44 +373,48 @@ async function addComputeInstructions(
   computeUnitBuffer: ComputeUnitBuffer = {},
   commitment: Commitment = "confirmed",
 ): Promise<Array<TransactionInstruction>> {
-  instructions.push(
-    ComputeBudgetProgram.setComputeUnitPrice({
-      microLamports: priorityFee,
-    }),
-  );
-
-  const simulatedCompute = await getSimulationComputeUnits(
-    connection,
-    instructions,
-    payer,
-    lookupTables,
-    commitment,
-  );
-
-  if (simulatedCompute === null) {
-    throw new Error("Failed to simulate compute units");
-  }
-
-  console.log("Simulated compute units", simulatedCompute);
-
-  // Apply buffer to compute units
-  let finalComputeUnits = simulatedCompute;
-  if (computeUnitBuffer.multiplier) {
-    finalComputeUnits = Math.floor(
-      finalComputeUnits * computeUnitBuffer.multiplier,
+  if (!hasSetComputeUnitPriceInstruction(instructions)) {
+    instructions.push(
+      ComputeBudgetProgram.setComputeUnitPrice({
+        microLamports: priorityFee,
+      }),
     );
   }
-  if (computeUnitBuffer.fixed) {
-    finalComputeUnits += computeUnitBuffer.fixed;
+
+  if (!hasSetComputeLimitInstruction(instructions)) {
+    const simulatedCompute = await getSimulationComputeUnits(
+      connection,
+      instructions,
+      payer,
+      lookupTables,
+      commitment,
+    );
+
+    if (simulatedCompute === null) {
+      throw new Error("Failed to simulate compute units");
+    }
+
+    console.log("Simulated compute units", simulatedCompute);
+
+    // Apply buffer to compute units
+    let finalComputeUnits = simulatedCompute;
+    if (computeUnitBuffer.multiplier) {
+      finalComputeUnits = Math.floor(
+        finalComputeUnits * computeUnitBuffer.multiplier,
+      );
+    }
+    if (computeUnitBuffer.fixed) {
+      finalComputeUnits += computeUnitBuffer.fixed;
+    }
+
+    console.log("Final compute units (with buffer)", finalComputeUnits);
+
+    instructions.push(
+      ComputeBudgetProgram.setComputeUnitLimit({
+        units: finalComputeUnits,
+      }),
+    );
   }
-
-  console.log("Final compute units (with buffer)", finalComputeUnits);
-
-  instructions.push(
-    ComputeBudgetProgram.setComputeUnitLimit({
-      units: finalComputeUnits,
-    }),
-  );
 
   return instructions;
 }
@@ -645,9 +453,9 @@ async function addComputeInstructions(
  *
  * @internal This is an internal helper function used by sendVersionedTransaction
  */
-async function sendVersionedTransactionWithRetry(
+async function sendRawTransactionWithRetry(
   connection: Connection,
-  transaction: VersionedTransaction,
+  transaction: Uint8Array,
   {
     maxRetries = DEFAULT_SEND_OPTIONS.maxRetries,
     initialDelayMs = DEFAULT_SEND_OPTIONS.initialDelayMs,
@@ -670,7 +478,7 @@ async function sendVersionedTransactionWithRetry(
       const isFirstSend = signature === null;
 
       // Send transaction if not sent yet
-      signature = await connection.sendRawTransaction(transaction.serialize(), {
+      signature = await connection.sendRawTransaction(transaction, {
         skipPreflight,
         preflightCommitment: commitment,
         maxRetries: 0,

--- a/tests/src/idl.test.ts
+++ b/tests/src/idl.test.ts
@@ -2,7 +2,7 @@ import { describe, test } from "node:test";
 import { Connection, PublicKey } from "@solana/web3.js";
 import {
   decodeAnchorTransaction,
-  getIDlByProgramId,
+  getIdlByProgramId,
   getIdlParsedAccountData,
   parseAnchorTransactionEvents,
 } from "../../src";
@@ -15,7 +15,7 @@ const MAINNET = "https://api.mainnet-beta.solana.com";
 describe("confirmTransaction", () => {
   test("Parsing verify transaction contains two events", async () => {
     const connection = new Connection(MAINNET);
-    const idl: Idl = await getIDlByProgramId(
+    const idl: Idl = await getIdlByProgramId(
       new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
       connection,
     );
@@ -36,7 +36,7 @@ describe("confirmTransaction", () => {
       "ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES",
     );
 
-    const idl: Idl | null = await getIDlByProgramId(programId, connection);
+    const idl: Idl | null = await getIdlByProgramId(programId, connection);
     if (!idl)
       throw new Error(`IDL not found for program ${programId.toString()}`);
 
@@ -90,7 +90,7 @@ describe("confirmTransaction", () => {
       "ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES",
     );
 
-    const idl: Idl | null = await getIDlByProgramId(programId, connection);
+    const idl: Idl | null = await getIdlByProgramId(programId, connection);
     if (!idl)
       throw new Error(`IDL not found for program ${programId.toString()}`);
 
@@ -134,7 +134,7 @@ describe("confirmTransaction", () => {
 
   test("Parsing verify account returns correct data", async () => {
     const connection = new Connection(MAINNET);
-    const idl: Idl = await getIDlByProgramId(
+    const idl: Idl = await getIdlByProgramId(
       new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
       connection,
     );
@@ -172,6 +172,9 @@ describe("confirmTransaction", () => {
     );
     assert.ok(Array.isArray(buildParams.args), "Should have args array");
     assert.ok(buildParams.deploySlot, "Should have deploySlot");
-    assert.ok(typeof buildParams.bump === "number", "Should have bump of type number");
+    assert.ok(
+      typeof buildParams.bump === "number",
+      "Should have bump of type number",
+    );
   });
 });

--- a/tests/src/idl.test.ts
+++ b/tests/src/idl.test.ts
@@ -13,7 +13,7 @@ const DEVNET = "https://api.devnet.solana.com";
 const MAINNET = "https://api.mainnet-beta.solana.com";
 
 describe("confirmTransaction", () => {
-  test("Parsing verify transaction containts two events", async () => {
+  test("Parsing verify transaction contains two events", async () => {
     const connection = new Connection(MAINNET);
     const idl: Idl = await getIDlByProgramId(
       new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
@@ -40,7 +40,7 @@ describe("confirmTransaction", () => {
     if (!idl)
       throw new Error(`IDL not found for program ${programId.toString()}`);
 
-    var counterTranscation = await decodeAnchorTransaction(
+    var counterTransaction = await decodeAnchorTransaction(
       idl,
       "56nR9azAzpwTCNSJ5Qtnwz9DExogNav7uXQDKBpQ8oRcadYakngrT3QRp7ZLFSuiQxjbbFX6NCiQ2aSaPEugxiLf",
       connection,
@@ -48,17 +48,17 @@ describe("confirmTransaction", () => {
     );
     console.log(
       "Counter increase transaction",
-      JSON.stringify(counterTranscation, null, 2),
+      JSON.stringify(counterTransaction, null, 2),
     );
 
     // Assert transaction structure
     assert.equal(
-      counterTranscation.instructions.length,
+      counterTransaction.instructions.length,
       1,
       "Should have one instruction",
     );
 
-    const instruction = counterTranscation.instructions[0];
+    const instruction = counterTransaction.instructions[0];
     assert.equal(
       instruction.name,
       "increment",

--- a/tests/src/idl.test.ts
+++ b/tests/src/idl.test.ts
@@ -1,0 +1,177 @@
+import { describe, test } from "node:test";
+import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  decodeAnchorTransaction,
+  getIDlByProgramId,
+  getIdlParsedAccountData,
+  parseAnchorTransactionEvents,
+} from "../../src";
+import assert from "node:assert";
+import { Idl } from "@coral-xyz/anchor";
+
+const DEVNET = "https://api.devnet.solana.com";
+const MAINNET = "https://api.mainnet-beta.solana.com";
+
+describe("confirmTransaction", () => {
+  test("Parsing verify transaction containts two events", async () => {
+    const connection = new Connection(MAINNET);
+    const idl: Idl = await getIDlByProgramId(
+      new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
+      connection,
+    );
+
+    var events = await parseAnchorTransactionEvents(
+      idl,
+      "51f5WEqS7VSaeyg1o7qSY4oVqbuzxm4tCe7woSBKdSgxqkp9h1ebJLV5nKhaLHYohkSaV4Kaccs1ye8CexhBhgG6",
+      connection,
+    );
+    console.log("Events", JSON.stringify(events, null, 2));
+    assert.equal(events.length, 1, "Should have two events");
+    assert.equal(events[0].name, "otterVerifyEvent", "Its a otterVerifyEvent");
+  });
+
+  test("Decoding transaction returns correct data", async () => {
+    const connection = new Connection(DEVNET);
+    const programId = new PublicKey(
+      "ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES",
+    );
+
+    const idl: Idl | null = await getIDlByProgramId(programId, connection);
+    if (!idl)
+      throw new Error(`IDL not found for program ${programId.toString()}`);
+
+    var counterTranscation = await decodeAnchorTransaction(
+      idl,
+      "56nR9azAzpwTCNSJ5Qtnwz9DExogNav7uXQDKBpQ8oRcadYakngrT3QRp7ZLFSuiQxjbbFX6NCiQ2aSaPEugxiLf",
+      connection,
+      programId,
+    );
+    console.log(
+      "Counter increase transaction",
+      JSON.stringify(counterTranscation, null, 2),
+    );
+
+    // Assert transaction structure
+    assert.equal(
+      counterTranscation.instructions.length,
+      1,
+      "Should have one instruction",
+    );
+
+    const instruction = counterTranscation.instructions[0];
+    assert.equal(
+      instruction.name,
+      "increment",
+      "Should be increment instruction",
+    );
+    assert.deepEqual(instruction.data, {}, "Should have empty data");
+
+    // Assert accounts
+    assert.equal(instruction.accounts.length, 2, "Should have two accounts");
+
+    const [signer, counter] = instruction.accounts;
+    assert.equal(signer.name, "signer", "First account should be signer");
+    assert.equal(signer.pubkey, "5vJwnLeyjV8uNJSp1zn7VLW8GwiQbcsQbGaVSwRmkE4r");
+    assert.equal(signer.isSigner, true, "Signer should be a signer");
+    assert.equal(signer.isWritable, true, "Signer should be writable");
+
+    assert.equal(counter.name, "counter", "Second account should be counter");
+    assert.equal(
+      counter.pubkey,
+      "BGBMtk7oqrb4qAZa6v6sZPKpC8BJoEunxc2LJSi5BPPc",
+    );
+    assert.equal(counter.isSigner, false, "Counter should not be a signer");
+    assert.equal(counter.isWritable, true, "Counter should be writable");
+  });
+
+  test("Decode versioned transaction", async () => {
+    const connection = new Connection(DEVNET);
+    const programId = new PublicKey(
+      "ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES",
+    );
+
+    const idl: Idl | null = await getIDlByProgramId(programId, connection);
+    if (!idl)
+      throw new Error(`IDL not found for program ${programId.toString()}`);
+
+    var versionedTransactionDecoded = await decodeAnchorTransaction(
+      idl,
+      "4sh5VrmTpiQjNaaNgHiDtd6QCnEjQHKS5tcq4nobUoWnFeAEQVLUTqdTbVJYCbHNPHDPSjxiUeK7qXsQwFSTrSmg",
+      connection,
+      programId,
+    );
+    console.log(
+      "VerifyTransaction",
+      JSON.stringify(versionedTransactionDecoded, null, 2),
+    );
+
+    // Assert transaction structure
+    assert.equal(
+      versionedTransactionDecoded.instructions.length,
+      1,
+      "Should have one instruction",
+    );
+
+    const instruction = versionedTransactionDecoded.instructions[0];
+    assert.equal(
+      instruction.name,
+      "initialize",
+      "Should be initialize instruction",
+    );
+
+    // Assert counter account data
+    const counterAccount = instruction.accounts.find(
+      (acc) => acc.name === "counter",
+    );
+    assert.ok(counterAccount, "Counter account should exist");
+    assert.ok(counterAccount.data, "Counter account should have data");
+    assert.equal(
+      counterAccount.data.count.toString(),
+      "1",
+      "Counter should be initialized to 1",
+    );
+  });
+
+  test("Parsing verify account returns correct data", async () => {
+    const connection = new Connection(MAINNET);
+    const idl: Idl = await getIDlByProgramId(
+      new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
+      connection,
+    );
+
+    var accountData = await getIdlParsedAccountData(
+      idl,
+      "buildParams",
+      new PublicKey("NRBNcTmfRkZWCLwnd6ygiz8CYerneu6m5Hcchx8RbFD"),
+      connection,
+    );
+    console.log("Account data", JSON.stringify(accountData, null, 2));
+
+    // Type assertion for better IDE support
+    const buildParams = accountData as {
+      address: string;
+      signer: string;
+      version: string;
+      gitUrl: string;
+      commit: string;
+      args: string[];
+      deploySlot: string;
+      bump: number;
+    };
+
+    assert.ok(buildParams.address, "Should have address");
+    assert.ok(buildParams.signer, "Should have signer");
+    assert.ok(buildParams.version, "Should have version");
+    assert.ok(
+      buildParams.gitUrl.includes("github.com"),
+      "Should have valid git URL",
+    );
+    assert.ok(
+      buildParams.commit.length === 40,
+      "Should have valid commit hash",
+    );
+    assert.ok(Array.isArray(buildParams.args), "Should have args array");
+    assert.ok(buildParams.deploySlot, "Should have deploySlot");
+    assert.ok(typeof buildParams.bump === "number", "Should have bump of type number");
+  });
+});

--- a/tests/src/idl.test.ts
+++ b/tests/src/idl.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from "node:test";
 import { Connection, PublicKey } from "@solana/web3.js";
 import {
+  createProviderForConnection,
   decodeAnchorTransaction,
   getIdlByProgramId,
   getIdlParsedAccountData,
@@ -15,15 +16,16 @@ const MAINNET = "https://api.mainnet-beta.solana.com";
 describe("confirmTransaction", () => {
   test("Parsing verify transaction contains two events", async () => {
     const connection = new Connection(MAINNET);
+    const provider = createProviderForConnection(connection);
     const idl: Idl = await getIdlByProgramId(
       new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
-      connection,
+      provider,
     );
 
     var events = await parseAnchorTransactionEvents(
       idl,
       "51f5WEqS7VSaeyg1o7qSY4oVqbuzxm4tCe7woSBKdSgxqkp9h1ebJLV5nKhaLHYohkSaV4Kaccs1ye8CexhBhgG6",
-      connection,
+      provider,
     );
     console.log("Events", JSON.stringify(events, null, 2));
     assert.equal(events.length, 1, "Should have two events");
@@ -32,18 +34,19 @@ describe("confirmTransaction", () => {
 
   test("Decoding transaction returns correct data", async () => {
     const connection = new Connection(DEVNET);
+    const provider = createProviderForConnection(connection);
     const programId = new PublicKey(
       "ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES",
     );
 
-    const idl: Idl | null = await getIdlByProgramId(programId, connection);
+    const idl: Idl | null = await getIdlByProgramId(programId, provider);
     if (!idl)
       throw new Error(`IDL not found for program ${programId.toString()}`);
 
     var counterTransaction = await decodeAnchorTransaction(
       idl,
       "56nR9azAzpwTCNSJ5Qtnwz9DExogNav7uXQDKBpQ8oRcadYakngrT3QRp7ZLFSuiQxjbbFX6NCiQ2aSaPEugxiLf",
-      connection,
+      provider,
       programId,
     );
     console.log(
@@ -86,18 +89,19 @@ describe("confirmTransaction", () => {
 
   test("Decode versioned transaction", async () => {
     const connection = new Connection(DEVNET);
+    const provider = createProviderForConnection(connection);
     const programId = new PublicKey(
       "ancA4duevpt3eSgS5J7cD8oJntmfLKJDM59GhMtegES",
     );
 
-    const idl: Idl | null = await getIdlByProgramId(programId, connection);
+    const idl: Idl | null = await getIdlByProgramId(programId, provider);
     if (!idl)
       throw new Error(`IDL not found for program ${programId.toString()}`);
 
     var versionedTransactionDecoded = await decodeAnchorTransaction(
       idl,
       "4sh5VrmTpiQjNaaNgHiDtd6QCnEjQHKS5tcq4nobUoWnFeAEQVLUTqdTbVJYCbHNPHDPSjxiUeK7qXsQwFSTrSmg",
-      connection,
+      provider,
       programId,
     );
     console.log(
@@ -134,16 +138,17 @@ describe("confirmTransaction", () => {
 
   test("Parsing verify account returns correct data", async () => {
     const connection = new Connection(MAINNET);
+    const provider = createProviderForConnection(connection);
     const idl: Idl = await getIdlByProgramId(
       new PublicKey("verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC"),
-      connection,
+      provider,
     );
 
     var accountData = await getIdlParsedAccountData(
       idl,
       "buildParams",
       new PublicKey("NRBNcTmfRkZWCLwnd6ygiz8CYerneu6m5Hcchx8RbFD"),
-      connection,
+      provider,
     );
     console.log("Account data", JSON.stringify(accountData, null, 2));
 

--- a/tests/src/transaction.test.ts
+++ b/tests/src/transaction.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   airdropIfRequired,
   confirmTransaction,
-  CreateLookupTable,
+  createLookupTable,
   getSimulationComputeUnits,
   prepareTransactionWithCompute,
   sendTransaction,
@@ -248,14 +248,14 @@ describe("Transaction utilities", () => {
     const recipient2 = Keypair.generate();
     const recipient3 = Keypair.generate();
 
-    const [lookupTableAddress, lookupTableAccount] = await CreateLookupTable(
+    const [lookupTableAddress, lookupTableAccount] = await createLookupTable(
       connection,
       sender,
       [
         sender.publicKey,
         recipient.publicKey,
         recipient2.publicKey,
-        recipient3.publicKey
+        recipient3.publicKey,
       ],
     );
 


### PR DESCRIPTION
- Added `sendVersionedTransaction()` to send a versioned transaction with lookup tables. Also adds priority fee support.
- Added `createLookupTable()` to easily create a lookup table and extend it with additional addresses
- Added `getIDlByProgramId()` to fetch an IDL from a program on-chain
- Added `getIDlByIdlPath()` to parse an IDL from a local file path
- Added `getIdlParsedAccountData()` to parse account data using an IDL
- Added `parseAnchorTransactionEvents()` to parse anchor transaction events using an IDL
- Added `decodeAnchorTransaction()` to decode a transaction completely using an IDL
- Fixed account data parsing in `decodeAnchorTransaction()`