### PR TITLE
fix: nodewallet and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.8.1
+
+- Fix issue with CJS import of Anchor's `NodeWallet` to use the correct `Wallet` class exported
+- Fixed type errors on `ArrayBuffer`s and `Uint8Array`s
+
 ## 2.8
 
 - Added `sendVersionedTransaction()` to send a versioned transaction with lookup tables. Also adds priority fee support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana-developers/helpers",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana-developers/helpers",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Solana helper functions",
   "type": "module",
   "main": "./dist/esm/index.js",


### PR DESCRIPTION
## Problem

the `NodeWallet` import is only valid for CJS, not all javascript stacks. running some scripts, like the ones in the [solana basics workshop](https://github.com/solana-developers/workshop-solana-basics), may result in errors.

from testing, it seems using `npm` to install the packages in that repo results in the error. but using `pnpm` does not, which is why this was not caught before 

## Summary of Changes
- removed the `NodeWallet` import for the correct `Wallet` import
- fixed a few type errors for `Uint8Array` vs `Buffer`

Fixes: #79 